### PR TITLE
Fix typo in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-versions: 2
+version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Essentially all in the PR name. Fixing a typo (versions) in the dependabot config.