### PR TITLE
Add Codespell to Style CI Workflow

### DIFF
--- a/.github/workflows/requirements/style.txt
+++ b/.github/workflows/requirements/style.txt
@@ -1,2 +1,3 @@
 black==23.12.0
 flake8==6.1.0
+codespell==2.2.6

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -25,3 +25,4 @@ jobs:
         run: |
           black --diff --check .
           flake8 hubcast/
+          codespell

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ to reach out and ask for help when getting started.
 
 For small changes (e.g. bug fixes), feel free to submit a PR.
 
-For larger architectual changes and new features, consider opening an
+For larger architectural changes and new features, consider opening an
 [issue](https://github.com/LLNL/hubcast/issues/new?template=issue-feature-request.md) outlining your
 proposed contribution.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -153,7 +153,7 @@ inside the repository by following the instructions
 [here](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html#create-a-project-access-token).
 
 > [!TIP]
-> To ensure Hubcast can opperate sucessfully you'll need to give the following permissions
+> To ensure Hubcast can operate successfully you'll need to give the following permissions
 > to the project access token,
 > - `read_api`
 > - `read_repository`


### PR DESCRIPTION
Adding `codespell` to the CI style workflow to prevent us (me) from misspelling anything too badly.