### PR TITLE
Refactor to consolidate config with `dynaconf` and `attrs`

### DIFF
--- a/.github/workflows/requirements/unit-tests.txt
+++ b/.github/workflows/requirements/unit-tests.txt
@@ -1,3 +1,5 @@
+attrs==23.1.0
+dynaconf==3.2.4
 tox==4.11.4
 pytest==7.4.4
 pytest-asyncio==0.23.2

--- a/.github/workflows/requirements/unit-tests.txt
+++ b/.github/workflows/requirements/unit-tests.txt
@@ -1,3 +1,4 @@
+aiohttp==3.9.1
 attrs==23.1.0
 dynaconf==3.2.4
 tox==4.11.4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__
 spack.lock
 .spack-env
 *.pem
+
+# Ignore dynaconf secret files
+.secrets.*

--- a/hubcast/__main__.py
+++ b/hubcast/__main__.py
@@ -61,11 +61,11 @@ async def main(request) -> web.Response:
 if __name__ == "__main__":
     print("Initializing hubcast ...")
     print("Configuring Git Repository ...")
-    if not os.path.exists(settings.git.repo_path):
-        os.makedirs(settings.git.repo_path)
+    if not os.path.exists(settings.git.base_path):
+        os.makedirs(settings.git.base_path)
         git("init")
-        git(f"remote add github {settings.github.repo}")
-        git(f"remote add gitlab {settings.gitlab.repo}")
+        git(f"remote add github {settings.github.url}")
+        git(f"remote add gitlab {settings.gitlab.url}")
 
     print("Starting Web Server...")
     app = web.Application()

--- a/hubcast/__main__.py
+++ b/hubcast/__main__.py
@@ -1,25 +1,61 @@
 import os
-from aiohttp import web
+from aiohttp import web, ClientSession
+from gidgethub import aiohttp as gh_aiohttp
+from gidgetlab import aiohttp as gl_aiohttp
 
+from .auth.github import get_installation_id, authenticate_installation
 from .config import settings
 from .github import github
 from .gitlab import gitlab
+from .models import HubcastRepo, HubcastRepoCache
 from .utils.git import Git
 
 
-github_settings = settings.github.to_dict()
-git_settings = settings.git.to_dict()
-git = Git(config=git_settings)
+repo_cache = HubcastRepoCache()
+git = Git(config=settings.git.to_dict())
+
+
+def make_github_client(
+    session: ClientSession, repo: HubcastRepo
+) -> gh_aiohttp.GitHubAPI:
+    # get installation id for configured repostitory
+    if not repo.github_config.installation_id:
+        repo.github_config.installation_id = await get_installation_id(repo)
+
+    # retrieve GitHub authentication token
+    gh_token = await authenticate_installation(repo)
+
+    return gh_aiohttp.GitHubAPI(
+        session, repo.github_config.requester, oauth_token=gh_token
+    )
+
+
+def make_gitlab_client(
+    session: ClientSession, repo: HubcastRepo
+) -> gl_aiohttp.GitLabAPI:
+    return gl_aiohttp.GitLabAPI(
+        session,
+        repo.gitlab_config.requester,
+        access_token=repo.gitlab_config.access_token,
+    )
 
 
 async def main(request) -> web.Response:
-    # route request to github or gitlab submodule based on event type header
-    if "x-github-event" in request.headers:
-        return await github(request, github_settings, git_settings)
-    elif "x-gitlab-event" in request.headers:
-        return await gitlab(request)
-    else:
-        return web.Response(status=404)
+    # suggested to use a single session for the lifetime of the application
+    # to take advantage of connection pooling
+    # see: https://docs.aiohttp.org/en/stable/client_reference.html#client-session
+    async with ClientSession() as session:
+        repo = repo_cache.get(name=settings.repo.name, config=settings.to_dict())
+        gh = make_github_client(session, repo)
+
+        # route request to github or gitlab submodule based on event type header
+        if "x-github-event" in request.headers:
+            return await github(session, request, repo, gh)
+        elif "x-gitlab-event" in request.headers:
+            gl = make_gitlab_client(session, repo)
+            return await gitlab(session, request, repo, gh, gl)
+        else:
+            return web.Response(status=404)
 
 
 if __name__ == "__main__":

--- a/hubcast/__main__.py
+++ b/hubcast/__main__.py
@@ -7,7 +7,7 @@ from .auth.github import get_installation_id, authenticate_installation
 from .config import settings
 from .github import github
 from .gitlab import gitlab
-from .models import HubcastRepo, HubcastRepoCache
+from .models import GitHubConfig, GitLabConfig, HubcastRepoCache
 from .utils.git import Git
 
 
@@ -16,27 +16,25 @@ git = Git(config=settings.git.to_dict())
 
 
 def make_github_client(
-    session: ClientSession, repo: HubcastRepo
+    session: ClientSession, github_config: GitHubConfig
 ) -> gh_aiohttp.GitHubAPI:
     # get installation id for configured repostitory
-    if not repo.github_config.installation_id:
-        repo.github_config.installation_id = await get_installation_id(repo)
+    if not github_config.installation_id:
+        github_config.installation_id = await get_installation_id(github_config)
 
     # retrieve GitHub authentication token
-    gh_token = await authenticate_installation(repo)
+    gh_token = await authenticate_installation(github_config)
 
     return gh_aiohttp.GitHubAPI(
-        session, repo.github_config.requester, oauth_token=gh_token
+        session, github_config.requester, oauth_token=gh_token
     )
 
 
 def make_gitlab_client(
-    session: ClientSession, repo: HubcastRepo
+    session: ClientSession, gitlab_config: GitLabConfig
 ) -> gl_aiohttp.GitLabAPI:
     return gl_aiohttp.GitLabAPI(
-        session,
-        repo.gitlab_config.requester,
-        access_token=repo.gitlab_config.access_token,
+        session, gitlab_config.requester, access_token=gitlab_config.access_token
     )
 
 
@@ -46,13 +44,13 @@ async def main(request) -> web.Response:
     # see: https://docs.aiohttp.org/en/stable/client_reference.html#client-session
     async with ClientSession() as session:
         repo = repo_cache.get(name=settings.repo.name, config=settings.to_dict())
-        gh = make_github_client(session, repo)
+        gh = make_github_client(session, repo.github_config)
 
         # route request to github or gitlab submodule based on event type header
         if "x-github-event" in request.headers:
             return await github(session, request, repo, gh)
         elif "x-gitlab-event" in request.headers:
-            gl = make_gitlab_client(session, repo)
+            gl = make_gitlab_client(session, repo.gitlab_config)
             return await gitlab(session, request, repo, gh, gl)
         else:
             return web.Response(status=404)

--- a/hubcast/__main__.py
+++ b/hubcast/__main__.py
@@ -25,9 +25,7 @@ def make_github_client(
     # retrieve GitHub authentication token
     gh_token = await authenticate_installation(github_config)
 
-    return gh_aiohttp.GitHubAPI(
-        session, github_config.requester, oauth_token=gh_token
-    )
+    return gh_aiohttp.GitHubAPI(session, github_config.requester, oauth_token=gh_token)
 
 
 def make_gitlab_client(

--- a/hubcast/__main__.py
+++ b/hubcast/__main__.py
@@ -1,4 +1,3 @@
-import os
 from aiohttp import web, ClientSession
 from gidgethub import aiohttp as gh_aiohttp
 from gidgetlab import aiohttp as gl_aiohttp
@@ -8,7 +7,6 @@ from .config import settings
 from .github import github
 from .gitlab import gitlab
 from .models import GitHubConfig, GitLabConfig, HubcastRepo, HubcastRepoCache
-from .utils.git import Git
 
 
 repo_cache = HubcastRepoCache()
@@ -35,14 +33,6 @@ def make_gitlab_client(
     )
 
 
-def init_git_repo(repo: HubcastRepo):
-    print(f"Initializing git repository for {repo.name} at {repo.git_repo_path}")
-    git = Git(base_path=repo.git_repo_path)
-    git("init")
-    git(f"remote add github {repo.github_config.url}")
-    git(f"remote add gitlab {repo.gitlab_config.url}")
-
-
 async def main(request) -> web.Response:
     # TODO: move main handler to closure to house session for app lifetime
     # suggested to use a single session for the lifetime of the application
@@ -51,9 +41,6 @@ async def main(request) -> web.Response:
     async with ClientSession() as session:
         repo = repo_cache.get(name=settings.repo.name, config=settings.to_dict())
 
-        if not os.path.exists(repo.git_repo_path):
-            os.makedirs(repo.git_repo_path)
-            init_git_repo(repo)
 
         gh = await make_github_client(session, repo.github_config)
 

--- a/hubcast/__main__.py
+++ b/hubcast/__main__.py
@@ -12,32 +12,51 @@ from .models import HubcastRepoCache
 repo_cache = HubcastRepoCache()
 
 
-async def main(request) -> web.Response:
-    # TODO: move main handler to closure to house session for app lifetime
-    # suggested to use a single session for the lifetime of the application
-    # to take advantage of connection pooling
-    # see: https://docs.aiohttp.org/en/stable/client_reference.html#client-session
-    async with ClientSession() as session:
-        repo = repo_cache.get(name=settings.repo.name, config=settings.to_dict())
+async def handler(request: web.Request) -> web.Response:
+    session = request.app["client_session"]
+    repo = repo_cache.get(name=settings.repo.name, config=settings.to_dict())
 
-        if not repo.github_config.installation_id:
-            repo.github_config.installation_id = await get_installation_id(repo.github_config)
+    if not repo.github_config.installation_id:
+        repo.github_config.installation_id = await get_installation_id(
+            session, repo.github_config
+        )
 
-        # retrieve GitHub authentication token
-        gh_token = await authenticate_installation(repo.github_config)
+    # retrieve GitHub authentication token
+    gh_token = await authenticate_installation(session, repo.github_config)
 
-        gh = gh_aiohttp.GitHubAPI(session, repo.github_config.requester, oauth_token=gh_token)
+    gh = gh_aiohttp.GitHubAPI(
+        session, repo.github_config.requester, oauth_token=gh_token
+    )
 
-        # route request to github or gitlab submodule based on event type header
-        if "x-github-event" in request.headers:
-            return await github(session, request, repo, gh)
-        elif "x-gitlab-event" in request.headers:
-            gl = gl_aiohttp.GitLabAPI(
-                session, repo.gitlab_config.requester, access_token=repo.gitlab_config.access_token
-            )
-            return await gitlab(session, request, repo, gh, gl)
-        else:
-            return web.Response(status=404)
+    # route request to github or gitlab submodule based on event type header
+    if "x-github-event" in request.headers:
+        return await github(session, request, repo, gh)
+    elif "x-gitlab-event" in request.headers:
+        gl = gl_aiohttp.GitLabAPI(
+            session,
+            repo.gitlab_config.requester,
+            access_token=repo.gitlab_config.access_token,
+        )
+        return await gitlab(session, request, repo, gh, gl)
+    else:
+        return web.Response(status=404)
+
+
+async def client_session(app: web.Application):
+    """
+    Create a single session for our application's lifetime.
+    The single session takes advantage of connection pooling.
+    see: https://docs.aiohttp.org/en/stable/client_reference.html#client-session
+
+    This method is handled by cleanup_ctx which ensures proper startup and teardown
+    of our session.
+    ses: https://docs.aiohttp.org/en/stable/web_advanced.html#cleanup-context
+    """
+
+    session = ClientSession()
+    app["client_session"] = session
+    yield
+    await session.close()
 
 
 if __name__ == "__main__":
@@ -45,6 +64,6 @@ if __name__ == "__main__":
 
     print("Starting Web Server...")
     app = web.Application()
-    app.router.add_post("/", main)
-
+    app.router.add_post("/", handler)
+    app.cleanup_ctx.append(client_session)
     web.run_app(app, port=settings.hubcast.port)

--- a/hubcast/auth/github.py
+++ b/hubcast/auth/github.py
@@ -1,5 +1,3 @@
-import os
-import re
 import time
 
 import aiohttp
@@ -8,18 +6,10 @@ from attrs import define, field
 from gidgethub import aiohttp as gh_aiohttp
 from typing import Awaitable, Dict, Tuple
 
+from hubcast.models import HubcastRepo
+
 #: location for authenticated app to get a token for one of its installations
 INSTALLATION_TOKEN_URL = "app/installations/{installation_id}/access_tokens"
-
-
-@define
-class GitHubAuthException(Exception):
-    message: str = field()
-
-
-@define
-class MissingConfigException(GitHubAuthException):
-    pass
 
 
 @define
@@ -55,94 +45,62 @@ def parse_isotime(timestr) -> int:
     return int(time.mktime(time.strptime(timestr[:-1], "%Y-%m-%dT%H:%M:%S")))
 
 
-@define
-class App:
-    id: str = field()
-    requester: str = field()
-    url: str = field()
-    private_key_path: str = field()
-    owner: str = field()
-    repo: str = field()
-    private_key: str = field()
-    installation_id: str = field(default=None)
+async def get_jwt(repo: HubcastRepo) -> str:
+    """Get a JWT from cache, creating a new one if necessary."""
 
-    # TODO: The owner and repo attributes assume ssh style urls
-    @owner.default
-    def _owner(self):
-        return re.search(r"(?<=\:)[^\/]*", self.url, re.IGNORECASE).group()
+    async def renew_jwt() -> Tuple[int, str]:
+        # GitHub requires that you create a JWT signed with the application's
+        # private key. You need the app id and the private key, and you can
+        # use this gidgethub method to create the JWT.
+        now = time.time()
+        jwt = gha.get_jwt(
+            app_id=repo.github_config.app_id, private_key=repo.github_config.private_key
+        )
 
-    @repo.default
-    def _repo(self):
-        return re.search(r"(?<=\/)[^.]*", self.url, re.IGNORECASE).group()
+        # gidgethub JWT's expire after 10 minutes (you cannot change it)
+        return (now + 10 * 60), jwt
 
-    @private_key.default
-    def _private_key(self) -> str:
-        """Load private key from file."""
+    return await _tokens.get_token("JWT", renew_jwt)
 
-        # TODO: jwt seems to require a private key--confirm if this should fail early
-        if not os.path.exists(self.private_key_path):
-            raise MissingConfigException(
-                f"Unable to find private key for app {self.id} at {self.private_key_path}"
+
+async def get_installation_id(repo: HubcastRepo) -> str:
+    async with aiohttp.ClientSession() as session:
+        gh = gh_aiohttp.GitHubAPI(session, repo.github_config.requester)
+
+        result = await gh.getitem(
+            f"/repos/{repo.github_config.owner}/{repo.github_config.repo}/installation",
+            accept="application/vnd.github+json",
+            jwt=await get_jwt(repo),
+        )
+
+        return result["id"]
+
+
+async def authenticate_installation(repo: HubcastRepo) -> str:
+    """Get an installation access token for the application.
+    Renew the JWT if necessary, then use it to get an installation access
+    token from github, if necessary.
+    """
+
+    async def renew_installation_token() -> Tuple[int, str]:
+        async with aiohttp.ClientSession() as session:
+            gh = gh_aiohttp.GitHubAPI(session, repo.github_config.requester)
+
+            # Use the JWT to get a limited-life OAuth token for a particular
+            # installation of the app. Note that we get a JWT only when
+            # necessary -- when we need to renew the installation token.
+            result = await gh.post(
+                INSTALLATION_TOKEN_URL,
+                {"installation_id": repo.github_config.installation_id},
+                data=b"",
+                accept="application/vnd.github.machine-man-preview+json",
+                jwt=await get_jwt(repo),
             )
 
-        with open(self.private_key_path, "r") as handle:
-            return handle.read()
+            expires = parse_isotime(result["expires_at"])
+            token = result["token"]
+            return (expires, token)
 
-    async def get_jwt(self) -> str:
-        """Get a JWT from cache, creating a new one if necessary."""
-
-        async def renew_jwt() -> Tuple[int, str]:
-            # GitHub requires that you create a JWT signed with the application's
-            # private key. You need the app id and the private key, and you can
-            # use this gidgethub method to create the JWT.
-            now = time.time()
-            jwt = gha.get_jwt(app_id=self.id, private_key=self.private_key)
-
-            # gidgethub JWT's expire after 10 minutes (you cannot change it)
-            return (now + 10 * 60), jwt
-
-        return await _tokens.get_token("JWT", renew_jwt)
-
-    async def get_installation_id(self) -> str:
-        if not self.installation_id:
-            async with aiohttp.ClientSession() as session:
-                gh = gh_aiohttp.GitHubAPI(session, self.requester)
-
-                result = await gh.getitem(
-                    f"/repos/{self.owner}/{self.repo}/installation",
-                    accept="application/vnd.github+json",
-                    jwt=await self.get_jwt(),
-                )
-
-                self.installation_id = result["id"]
-
-        return self.installation_id
-
-    async def authenticate_installation(self) -> str:
-        """Get an installation access token for the application.
-        Renew the JWT if necessary, then use it to get an installation access
-        token from github, if necessary.
-        """
-
-        installation_id = await self.get_installation_id()
-
-        async def renew_installation_token() -> Tuple[int, str]:
-            async with aiohttp.ClientSession() as session:
-                gh = gh_aiohttp.GitHubAPI(session, self.requester)
-
-                # Use the JWT to get a limited-life OAuth token for a particular
-                # installation of the app. Note that we get a JWT only when
-                # necessary -- when we need to renew the installation token.
-                result = await gh.post(
-                    INSTALLATION_TOKEN_URL,
-                    {"installation_id": installation_id},
-                    data=b"",
-                    accept="application/vnd.github.machine-man-preview+json",
-                    jwt=await self.get_jwt(),
-                )
-
-                expires = parse_isotime(result["expires_at"])
-                token = result["token"]
-                return (expires, token)
-
-        return await _tokens.get_token(installation_id, renew_installation_token)
+    return await _tokens.get_token(
+        repo.github_config.installation_id, renew_installation_token
+    )

--- a/hubcast/auth/github.py
+++ b/hubcast/auth/github.py
@@ -4,33 +4,35 @@ import time
 
 import aiohttp
 import gidgethub.apps as gha
+from attrs import define, field
 from gidgethub import aiohttp as gh_aiohttp
-
-# get config from environment.
-GH_REPO = os.environ.get("HC_GH_REPO")
-GH_REQUESTER = os.environ.get("HC_GH_REQUESTER")
-GH_PRIVATE_KEY_PATH = os.environ.get("HC_GH_PRIVATE_KEY_PATH")
-GH_APP_IDENTIFIER = os.environ.get("HC_GH_APP_IDENTIFIER")
-
-# load private key from file if provided.
-if os.path.exists(GH_PRIVATE_KEY_PATH):
-    with open(GH_PRIVATE_KEY_PATH, "r") as handle:
-        GH_PRIVATE_KEY = handle.read()
+from typing import Awaitable, Dict, Tuple
 
 #: location for authenticated app to get a token for one of its installations
 INSTALLATION_TOKEN_URL = "app/installations/{installation_id}/access_tokens"
 
 
+@define
+class GitHubAuthException(Exception):
+    message: str = field()
+
+
+@define
+class MissingConfigException(GitHubAuthException):
+    pass
+
+
+@define
 class TokenCache:
     """
     Cache for web tokens with an expiration.
     """
 
-    def __init__(self):
-        # token name to (expiration, token) tuple
-        self._tokens = {}
+    _tokens: Dict[str, Tuple[int, str]] = field(factory=dict)
 
-    async def get_token(self, name, renew, *, time_needed=60):
+    async def get_token(
+        self, name: str, renew: Awaitable, *, time_needed: int = 60
+    ) -> str:
         """Get a cached token, or renew as needed."""
         expires, token = self._tokens.get(name, (0, ""))
 
@@ -46,82 +48,101 @@ class TokenCache:
 _tokens = TokenCache()
 
 
-async def authenticate_installation(installation_id):
-    """Get an installation access token for the application.
-    Renew the JWT if necessary, then use it to get an installation access
-    token from github, if necessary.
-    """
-
-    async def renew_installation_token():
-        async with aiohttp.ClientSession() as session:
-            gh = gh_aiohttp.GitHubAPI(session, GH_REQUESTER)
-
-            # Use the JWT to get a limited-life OAuth token for a particular
-            # installation of the app. Note that we get a JWT only when
-            # necessary -- when we need to renew the installation token.
-            result = await gh.post(
-                INSTALLATION_TOKEN_URL,
-                {"installation_id": installation_id},
-                data=b"",
-                accept="application/vnd.github.machine-man-preview+json",
-                jwt=await get_jwt(),
-            )
-
-            expires = parse_isotime(result["expires_at"])
-            token = result["token"]
-            return (expires, token)
-
-    return await _tokens.get_token(installation_id, renew_installation_token)
-
-
-def parse_isotime(timestr):
+def parse_isotime(timestr) -> int:
     """Convert UTC ISO 8601 time stamp to seconds in epoch"""
     if timestr[-1] != "Z":
         raise ValueError(f"Time String '{timestr}' not in UTC")
     return int(time.mktime(time.strptime(timestr[:-1], "%Y-%m-%dT%H:%M:%S")))
 
 
-async def get_jwt():
-    """Get a JWT from cache, creating a new one if necessary."""
+@define
+class App:
+    id: str = field()
+    requester: str = field()
+    url: str = field()
+    private_key_path: str = field()
+    owner: str = field()
+    repo: str = field()
+    private_key: str = field()
+    installation_id: str = field(default=None)
 
-    async def renew_jwt():
-        # GitHub requires that you create a JWT signed with the application's
-        # private key. You need the app id and the private key, and you can
-        # use this gidgethub method to create the JWT.
-        now = time.time()
-        jwt = gha.get_jwt(app_id=GH_APP_IDENTIFIER, private_key=GH_PRIVATE_KEY)
+    # TODO: The owner and repo attributes assume ssh style urls
+    @owner.default
+    def _owner(self):
+        return re.search(r"(?<=\:)[^\/]*", self.url, re.IGNORECASE).group()
 
-        # gidgethub JWT's expire after 10 minutes (you cannot change it)
-        return (now + 10 * 60), jwt
+    @repo.default
+    def _repo(self):
+        return re.search(r"(?<=\/)[^.]*", self.url, re.IGNORECASE).group()
 
-    return await _tokens.get_token("JWT", renew_jwt)
+    @private_key.default
+    def _private_key(self) -> str:
+        """Load private key from file."""
 
+        # TODO: jwt seems to require a private key--confirm if this should fail early
+        if not os.path.exists(self.private_key_path):
+            raise MissingConfigException(
+                f"Unable to find private key for app {self.id} at {self.private_key_path}"
+            )
 
-class IDStore:
-    def __init__(self):
-        self.id = None
-        self.owner = re.search(r"(?<=\:)[^\/]*", GH_REPO, re.IGNORECASE).group()
-        self.repo = re.search(r"(?<=\/)[^.]*", GH_REPO, re.IGNORECASE).group()
+        with open(self.private_key_path, "r") as handle:
+            return handle.read()
 
-    async def get_id(self):
-        if self.id is None:
+    async def get_jwt(self) -> str:
+        """Get a JWT from cache, creating a new one if necessary."""
+
+        async def renew_jwt() -> Tuple[int, str]:
+            # GitHub requires that you create a JWT signed with the application's
+            # private key. You need the app id and the private key, and you can
+            # use this gidgethub method to create the JWT.
+            now = time.time()
+            jwt = gha.get_jwt(app_id=self.id, private_key=self.private_key)
+
+            # gidgethub JWT's expire after 10 minutes (you cannot change it)
+            return (now + 10 * 60), jwt
+
+        return await _tokens.get_token("JWT", renew_jwt)
+
+    async def get_installation_id(self) -> str:
+        if not self.installation_id:
             async with aiohttp.ClientSession() as session:
-                gh = gh_aiohttp.GitHubAPI(session, GH_REQUESTER)
+                gh = gh_aiohttp.GitHubAPI(session, self.requester)
 
                 result = await gh.getitem(
                     f"/repos/{self.owner}/{self.repo}/installation",
                     accept="application/vnd.github+json",
-                    jwt=await get_jwt(),
+                    jwt=await self.get_jwt(),
                 )
 
-                self.id = result["id"]
+                self.installation_id = result["id"]
 
-        return self.id
+        return self.installation_id
 
+    async def authenticate_installation(self) -> str:
+        """Get an installation access token for the application.
+        Renew the JWT if necessary, then use it to get an installation access
+        token from github, if necessary.
+        """
 
-_id_store = IDStore()
+        installation_id = await self.get_installation_id()
 
+        async def renew_installation_token() -> Tuple[int, str]:
+            async with aiohttp.ClientSession() as session:
+                gh = gh_aiohttp.GitHubAPI(session, self.requester)
 
-async def get_installation_id():
-    """Get an installation ID that has access to the given repo url."""
-    return await _id_store.get_id()
+                # Use the JWT to get a limited-life OAuth token for a particular
+                # installation of the app. Note that we get a JWT only when
+                # necessary -- when we need to renew the installation token.
+                result = await gh.post(
+                    INSTALLATION_TOKEN_URL,
+                    {"installation_id": installation_id},
+                    data=b"",
+                    accept="application/vnd.github.machine-man-preview+json",
+                    jwt=await self.get_jwt(),
+                )
+
+                expires = parse_isotime(result["expires_at"])
+                token = result["token"]
+                return (expires, token)
+
+        return await _tokens.get_token(installation_id, renew_installation_token)

--- a/hubcast/config.py
+++ b/hubcast/config.py
@@ -1,0 +1,8 @@
+"""Hubcast config."""
+from dynaconf import Dynaconf
+
+settings = Dynaconf(
+    envvar_prefix="HC",
+    settings_files=['settings.toml', '.secrets.toml'],
+    environments=True,
+)

--- a/hubcast/config.py
+++ b/hubcast/config.py
@@ -3,6 +3,6 @@ from dynaconf import Dynaconf
 
 settings = Dynaconf(
     envvar_prefix="HC",
-    settings_files=['settings.toml', '.secrets.toml'],
+    settings_files=["settings.toml", ".secrets.toml"],
     environments=True,
 )

--- a/hubcast/github.py
+++ b/hubcast/github.py
@@ -1,60 +1,31 @@
 import sys
 import traceback
 
-import aiohttp
-from aiohttp import web
-from attrs import define, field
-from gidgethub import aiohttp as gh_aiohttp
+from aiohttp import web, ClientSession
 from gidgethub import sansio
-from typing import Dict
+from gidgethub import aiohttp as gh_aiohttp
 
-from .auth.github import App
+from .models import HubcastRepo
 from .routes.github import router
 
 
-@define
-class AppCache:
-    _apps: Dict[str, App] = field(factory=dict)
-
-    def get_app(self, app_id: str, config: dict) -> App:
-        if not self._apps[app_id]:
-            self._apps[app_id] = App(
-                id=app_id,
-                requester=config["requester"],
-                url=config["repo"],
-                private_key_path=config["private_key_path"],
-            )
-
-        return self._apps[app_id]
-
-
-_app_cache = AppCache()
-
-
 async def github(
-    request: web.Request, github_config: dict, git_config: dict
+    session: ClientSession,
+    request: web.Request,
+    repo: HubcastRepo,
+    gh: gh_aiohttp.GitHubAPI,
 ) -> web.Response:
     try:
-        app = _app_cache.get_app(github_config["app_id"], github_config)
-
         # read the GitHub webhook payload
         body = await request.read()
 
         event = sansio.Event.from_http(
-            request.headers, body, secret=github_config["secret"]
+            request.headers, body, secret=repo.github_config.secret
         )
         print("GH delivery ID", event.delivery_id, file=sys.stderr)
 
-        # retrieve GitHub authentication token
-        token = await app.authenticate_installation()
-
-        async with aiohttp.ClientSession() as session:
-            gh = gh_aiohttp.GitHubAPI(
-                session, github_config["requester"], oauth_token=token
-            )
-
-            # call the appropriate callback for the event
-            await router.dispatch(event, gh, git_config, session=session)
+        # call the appropriate callback for the event
+        await router.dispatch(event, repo, gh, session=session)
 
         # return a "Success"
         return web.Response(status=200)

--- a/hubcast/github.py
+++ b/hubcast/github.py
@@ -14,7 +14,7 @@ from .routes.github import router
 
 @define
 class AppCache:
-    _apps: Dict[str, App] = field()
+    _apps: Dict[str, App] = field(factory=dict)
 
     def get_app(self, app_id: str, config: dict) -> App:
         if not self._apps[app_id]:

--- a/hubcast/github.py
+++ b/hubcast/github.py
@@ -33,7 +33,7 @@ async def github(request):
             gh = gh_aiohttp.GitHubAPI(session, GH_REQUESTER, oauth_token=token)
 
             # call the appropriate callback for the event
-            await router.dispatch(event, gh, session=session)
+            await router.dispatch(event, gh, git_config, session=session)
 
         # return a "Success"
         return web.Response(status=200)

--- a/hubcast/github.py
+++ b/hubcast/github.py
@@ -1,36 +1,57 @@
-import os
 import sys
 import traceback
 
 import aiohttp
 from aiohttp import web
+from attrs import define, field
 from gidgethub import aiohttp as gh_aiohttp
 from gidgethub import sansio
+from typing import Dict
 
-from .auth.github import authenticate_installation, get_installation_id
+from .auth.github import App
 from .routes.github import router
 
-# Get configuration from environment
-GH_SECRET = os.environ.get("HC_GH_SECRET")
-GH_REQUESTER = os.environ.get("HC_GH_REQUESTER")
+
+@define
+class AppCache:
+    _apps: Dict[str, App] = field()
+
+    def get_app(self, app_id: str, config: dict) -> App:
+        if not self._apps[app_id]:
+            self._apps[app_id] = App(
+                id=app_id,
+                requester=config["requester"],
+                url=config["repo"],
+                private_key_path=config["private_key_path"],
+            )
+
+        return self._apps[app_id]
 
 
-async def github(request):
+_app_cache = AppCache()
+
+
+async def github(
+    request: web.Request, github_config: dict, git_config: dict
+) -> web.Response:
     try:
+        app = _app_cache.get_app(github_config["app_id"], github_config)
+
         # read the GitHub webhook payload
         body = await request.read()
 
-        event = sansio.Event.from_http(request.headers, body, secret=GH_SECRET)
+        event = sansio.Event.from_http(
+            request.headers, body, secret=github_config["secret"]
+        )
         print("GH delivery ID", event.delivery_id, file=sys.stderr)
 
-        # get installation id for configured repostitory
-        installation_id = await get_installation_id()
-
         # retrieve GitHub authentication token
-        token = await authenticate_installation(installation_id)
+        token = await app.authenticate_installation()
 
         async with aiohttp.ClientSession() as session:
-            gh = gh_aiohttp.GitHubAPI(session, GH_REQUESTER, oauth_token=token)
+            gh = gh_aiohttp.GitHubAPI(
+                session, github_config["requester"], oauth_token=token
+            )
 
             # call the appropriate callback for the event
             await router.dispatch(event, gh, git_config, session=session)

--- a/hubcast/models.py
+++ b/hubcast/models.py
@@ -1,0 +1,78 @@
+import re
+from attrs import define, field
+from typing import Dict
+
+
+@define
+class GitHubConfig:
+    app_id: str = field()
+    requester: str = field()
+    url: str = field()
+    private_key_path: str = field()
+    secret: str = field()
+    check_name: str = field()
+    owner: str = field()
+    repo: str = field()
+    private_key: str = field()
+    installation_id: str = field(default=None)
+
+    # TODO: The owner and repo attributes assume ssh style urls
+    @owner.default
+    def _owner(self):
+        return re.search(r"(?<=\:)[^\/]*", self.url, re.IGNORECASE).group()
+
+    @repo.default
+    def _repo(self):
+        return re.search(r"(?<=\/)[^.]*", self.url, re.IGNORECASE).group()
+
+    @private_key.default
+    def _private_key(self) -> str:
+        """Load private key from file."""
+
+        # TODO: auth code seems to require a private key--confirm this method should fail fast
+        with open(self.private_key_path, "r") as handle:
+            return handle.read()
+
+
+@define
+class GitLabConfig:
+    url: str = field()
+    requester: str = field()
+    access_token: str = field()
+    secret: str = field()
+
+
+@define
+class HubcastRepo:
+    """Houses all data for a repo in hubcast including GitHub and GitLab config."""
+
+    # TODO: is name sufficiently unique or should we err on using uuids?
+    name: str = field()
+    config: dict = field()
+    git_repo_path: str = field()
+    github_config: GitHubConfig = field()
+    gitlab_config: GitLabConfig = field()
+
+    @git_repo_path.default
+    def _git_repo_path(self):
+        base_path = self.config["GIT"]["base_path"]
+        return f"{base_path}/{self.name}"
+
+    @github_config.default
+    def _github_config(self):
+        return GitHubConfig(**self.config["GITHUB"])
+
+    @gitlab_config.default
+    def _gitlab_config(self):
+        return GitLabConfig(**self.config["GITLAB"])
+
+
+@define
+class HubcastRepoCache:
+    _repos: Dict[str, HubcastRepo] = field(factory=dict)
+
+    def get(self, name: str, config: dict) -> HubcastRepo:
+        if not self._repos[name]:
+            self._repos[name] = HubcastRepo(name=name, config=config)
+
+        return self._repos[name]

--- a/hubcast/models.py
+++ b/hubcast/models.py
@@ -72,7 +72,7 @@ class HubcastRepoCache:
     _repos: Dict[str, HubcastRepo] = field(factory=dict)
 
     def get(self, name: str, config: dict) -> HubcastRepo:
-        if not self._repos[name]:
+        if name not in self._repos:
             self._repos[name] = HubcastRepo(name=name, config=config)
 
         return self._repos[name]

--- a/hubcast/models.py
+++ b/hubcast/models.py
@@ -2,7 +2,7 @@ import os
 import re
 from attrs import define, field
 from typing import Dict
-from .utils import Git, GitException
+from .utils.git import Git
 
 
 @define

--- a/hubcast/routes/github.py
+++ b/hubcast/routes/github.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from gidgethub import routing, sansio
 
-from ..utils.git import git
+from ..utils.git import Git
 
 
 class LabSyncRouter(routing.Router):
@@ -27,8 +27,9 @@ repo_lock = asyncio.Lock()
 @router.register("pull_request", action="opened")
 @router.register("pull_request", action="reopened")
 @router.register("pull_request", action="synchronize")
-async def sync_pr(event, gh, *arg, **kwargs):
+async def sync_pr(event, gh, git_config, *arg, **kwargs):
     """Sync the git fork/branch referenced in a PR to GitLab."""
+    git = Git(config=git_config)
     pull_request = event.data["pull_request"]
     pull_request_id = pull_request["number"]
     await repo_lock.acquire()
@@ -40,7 +41,8 @@ async def sync_pr(event, gh, *arg, **kwargs):
 
 
 @router.register("pull_request", action="closed")
-async def remove_pr(event, gh, *arg, **kwargs):
+async def remove_pr(event, gh, git_config, *arg, **kwargs):
+    git = Git(config=git_config)
     pull_request = event.data["pull_request"]
     pull_request_id = pull_request["number"]
     await repo_lock.acquire()

--- a/hubcast/routes/github.py
+++ b/hubcast/routes/github.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from gidgethub import routing, sansio
 
+from ..models import HubcastRepo
 from ..utils.git import Git
 
 
@@ -27,9 +28,9 @@ repo_lock = asyncio.Lock()
 @router.register("pull_request", action="opened")
 @router.register("pull_request", action="reopened")
 @router.register("pull_request", action="synchronize")
-async def sync_pr(event, gh, git_config, *arg, **kwargs):
+async def sync_pr(event, repo: HubcastRepo, gh, *arg, **kwargs):
     """Sync the git fork/branch referenced in a PR to GitLab."""
-    git = Git(config=git_config)
+    git = Git(config=repo.git_repo_path)
     pull_request = event.data["pull_request"]
     pull_request_id = pull_request["number"]
     await repo_lock.acquire()
@@ -41,8 +42,8 @@ async def sync_pr(event, gh, git_config, *arg, **kwargs):
 
 
 @router.register("pull_request", action="closed")
-async def remove_pr(event, gh, git_config, *arg, **kwargs):
-    git = Git(config=git_config)
+async def remove_pr(event, repo: HubcastRepo, gh, *arg, **kwargs):
+    git = Git(config=repo.git_repo_path)
     pull_request = event.data["pull_request"]
     pull_request_id = pull_request["number"]
     await repo_lock.acquire()

--- a/hubcast/routes/github.py
+++ b/hubcast/routes/github.py
@@ -30,7 +30,7 @@ repo_lock = asyncio.Lock()
 @router.register("pull_request", action="synchronize")
 async def sync_pr(event, repo: HubcastRepo, gh, *arg, **kwargs):
     """Sync the git fork/branch referenced in a PR to GitLab."""
-    git = Git(config=repo.git_repo_path)
+    git = Git(base_path=repo.git_repo_path)
     pull_request = event.data["pull_request"]
     pull_request_id = pull_request["number"]
     await repo_lock.acquire()
@@ -43,7 +43,7 @@ async def sync_pr(event, repo: HubcastRepo, gh, *arg, **kwargs):
 
 @router.register("pull_request", action="closed")
 async def remove_pr(event, repo: HubcastRepo, gh, *arg, **kwargs):
-    git = Git(config=repo.git_repo_path)
+    git = Git(base_path=repo.git_repo_path)
     pull_request = event.data["pull_request"]
     pull_request_id = pull_request["number"]
     await repo_lock.acquire()

--- a/hubcast/routes/gitlab.py
+++ b/hubcast/routes/gitlab.py
@@ -14,7 +14,13 @@ class HubCastRouter(routing.Router):
     """
 
     async def dispatch(
-        self, event: sansio.Event, repo: HubcastRepo, *args: Any, **kwargs: Any
+        self,
+        event: sansio.Event,
+        repo: HubcastRepo,
+        gh: gh_aiohttp.GitHubAPI,
+        gl: gl_aiohttp.GitLabAPI,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         """Dispatch an event to all registered function(s)."""
 
@@ -34,7 +40,7 @@ class HubCastRouter(routing.Router):
                     if event_value in data_values:
                         found_callbacks.extend(data_values[event_value])
         for callback in found_callbacks:
-            await callback(event, *args, **kwargs)
+            await callback(event, repo, gh, gl, *args, **kwargs)
 
 
 router = HubCastRouter()

--- a/hubcast/tests/conftest.py
+++ b/hubcast/tests/conftest.py
@@ -1,0 +1,56 @@
+import pytest
+
+from hubcast.models import HubcastRepo
+
+
+@pytest.fixture
+def owner():
+    return "LLNL"
+
+
+@pytest.fixture
+def repo():
+    return "hubcast"
+
+
+@pytest.fixture
+def url(owner, repo):
+    return f"git@github.com:{owner}/{repo}.git"
+
+
+@pytest.fixture
+def private_key_path(tmp_path_factory):
+    return str(tmp_path_factory.mktemp(__name__).joinpath("hubcast.key"))
+
+
+@pytest.fixture
+def private_key(private_key_path):
+    key = "private_key"
+    with open(private_key_path, "w") as fh:
+        fh.write(key)
+    return key
+
+
+@pytest.fixture
+def hubcast_config(url, private_key_path, private_key):
+    from hubcast.config import settings
+
+    settings.github.url = url
+    settings.github.private_key_path = private_key_path
+    return settings
+
+
+@pytest.fixture
+def hubcast_repo_name():
+    return "foo_repo"
+
+
+@pytest.fixture
+def hubcast_repo_factory(hubcast_repo_name):
+    def _factory(config):
+        return HubcastRepo(
+            name=hubcast_repo_name,
+            config=config,
+        )
+
+    return _factory

--- a/hubcast/tests/test_git.py
+++ b/hubcast/tests/test_git.py
@@ -20,19 +20,19 @@ def remote_url():
 
 
 @pytest.fixture
-def repo_path(tmp_path):
+def base_path(tmp_path):
     return str(tmp_path)
 
 
 @pytest.fixture
-def git(repo_path):
-    return Git(config={"repo_path": repo_path})
+def git(base_path):
+    return Git(config={"base_path": base_path})
 
 
-def test_basic_repo_operations(git, repo_path, remote_name, remote_url):
+def test_basic_repo_operations(git, base_path, remote_name, remote_url):
     # Setup
     config = ConfigParser()
-    config_path = f"{repo_path}/.git/config"
+    config_path = f"{base_path}/.git/config"
 
     # Execute
     git("init")

--- a/hubcast/tests/test_git.py
+++ b/hubcast/tests/test_git.py
@@ -1,0 +1,45 @@
+import pytest
+from configparser import ConfigParser
+from shutil import which
+from hubcast.utils.git import Git
+
+if not which("git"):
+    pytest.skip(
+        "Skipping git tests since git command not found", allow_module_level=True
+    )
+
+
+@pytest.fixture
+def remote_name():
+    return "github"
+
+
+@pytest.fixture
+def remote_url():
+    return "https://github.com/LLNL/hubcast.git"
+
+
+@pytest.fixture
+def repo_path(tmp_path):
+    return str(tmp_path)
+
+
+@pytest.fixture
+def git(repo_path):
+    return Git(config={"repo_path": repo_path})
+
+
+def test_basic_repo_operations(git, repo_path, remote_name, remote_url):
+    # Setup
+    config = ConfigParser()
+    config_path = f"{repo_path}/.git/config"
+
+    # Execute
+    git("init")
+    git(f"remote add {remote_name} {remote_url}")
+
+    # Verify
+    config.read(config_path)
+    actual_remote_key = next((key for key in config.keys() if remote_name in key), None)
+    actual_url = config[actual_remote_key]["url"]
+    assert actual_url == remote_url

--- a/hubcast/tests/test_github_auth.py
+++ b/hubcast/tests/test_github_auth.py
@@ -82,7 +82,7 @@ async def test_get_installation_id(
     hubcast_repo = hubcast_repo_factory(config)
 
     # Execute
-    actual_installation_id = await get_installation_id(hubcast_repo.github_config)
+    actual_installation_id = await get_installation_id(mock.Mock(), hubcast_repo.github_config)
 
     # Verify
     assert actual_installation_id == installation_id
@@ -121,7 +121,7 @@ async def test_authenticate_installation(
     hubcast_repo.github_config.installation_id = installation_id
 
     # Execute
-    actual_access_token = await authenticate_installation(hubcast_repo.github_config)
+    actual_access_token = await authenticate_installation(mock.Mock(), hubcast_repo.github_config)
 
     # Verify
     assert actual_access_token == access_token

--- a/hubcast/tests/test_github_auth.py
+++ b/hubcast/tests/test_github_auth.py
@@ -54,7 +54,7 @@ async def test_get_jwt(
     hubcast_repo = hubcast_repo_factory(config)
 
     # Execute
-    actual_jwt = await get_jwt(hubcast_repo)
+    actual_jwt = await get_jwt(hubcast_repo.github_config)
 
     # Verify
     assert actual_jwt == jwt
@@ -82,7 +82,7 @@ async def test_get_installation_id(
     hubcast_repo = hubcast_repo_factory(config)
 
     # Execute
-    actual_installation_id = await get_installation_id(hubcast_repo)
+    actual_installation_id = await get_installation_id(hubcast_repo.github_config)
 
     # Verify
     assert actual_installation_id == installation_id
@@ -121,7 +121,7 @@ async def test_authenticate_installation(
     hubcast_repo.github_config.installation_id = installation_id
 
     # Execute
-    actual_access_token = await authenticate_installation(hubcast_repo)
+    actual_access_token = await authenticate_installation(hubcast_repo.github_config)
 
     # Verify
     assert actual_access_token == access_token

--- a/hubcast/tests/test_github_auth.py
+++ b/hubcast/tests/test_github_auth.py
@@ -1,0 +1,189 @@
+import pytest
+from unittest import mock
+
+from hubcast.auth.github import App
+
+
+@pytest.fixture
+def app_id():
+    return "abc123"
+
+
+@pytest.fixture
+def installation_id():
+    return "installation123"
+
+
+@pytest.fixture
+def requester():
+    return "hubcast-bot"
+
+
+@pytest.fixture
+def owner():
+    return "LLNL"
+
+
+@pytest.fixture
+def repo():
+    return "hubcast"
+
+
+@pytest.fixture
+def url(owner, repo):
+    return f"git@github.com:{owner}/{repo}.git"
+
+
+@pytest.fixture
+def jwt():
+    return "jwt123"
+
+
+@pytest.fixture
+def iso_8601_timestamp():
+    return "2023-12-28T22:27:06Z"
+
+
+@pytest.fixture
+def access_token():
+    return "access123"
+
+
+@pytest.fixture
+def private_key_path(tmp_path_factory):
+    return str(tmp_path_factory.mktemp(__name__).joinpath("hubcast.key"))
+
+
+@pytest.fixture
+def private_key(private_key_path):
+    key = "private_key"
+    with open(private_key_path, "w") as fh:
+        fh.write(key)
+    return key
+
+
+@pytest.fixture
+def github_config(app_id, requester, url, private_key_path):
+    from hubcast.config import settings
+
+    config = settings.github.to_dict()
+    config["app_id"] = app_id
+    config["requester"] = requester
+    config["repo"] = url
+    config["private_key_path"] = private_key_path
+    return config
+
+
+@pytest.fixture
+def app_factory():
+    def _factory(config):
+        return App(
+            id=config["app_id"],
+            requester=config["requester"],
+            url=config["repo"],
+            private_key_path=config["private_key_path"],
+        )
+
+    return _factory
+
+
+def test_dynamic_app_attributes(app_factory, github_config, owner, repo, private_key):
+    # Setup/Execute
+    app = app_factory(github_config)
+
+    assert app.owner == owner
+    assert app.repo == repo
+    assert app.private_key == private_key
+
+
+@mock.patch("hubcast.auth.github.gha")
+async def test_get_jwt(mock_gha, app_factory, github_config, jwt, app_id, private_key):
+    # Setup
+    mock_gha.get_jwt.return_value = jwt
+    app = app_factory(github_config)
+
+    # Execute
+    actual_jwt = await app.get_jwt()
+
+    # Verify
+    assert actual_jwt == jwt
+    mock_gha.get_jwt.assert_called_once_with(app_id=app_id, private_key=private_key)
+
+
+@mock.patch("hubcast.auth.github.gha")
+@mock.patch("hubcast.auth.github.gh_aiohttp.GitHubAPI")
+async def test_get_installation_id(
+    MockGitHubAPI,
+    mock_gha,
+    app_factory,
+    github_config,
+    jwt,
+    installation_id,
+    app_id,
+    private_key,
+):
+    # Setup
+    mock_gha.get_jwt.return_value = jwt
+    mock_gh = MockGitHubAPI.return_value
+    mock_gh.getitem = mock.AsyncMock()
+    mock_gh.getitem.return_value = {"id": installation_id}
+    app = app_factory(github_config)
+
+    # Execute
+    actual_installation_id = await app.get_installation_id()
+
+    # Verify
+    assert actual_installation_id == installation_id
+    mock_gh.getitem.assert_awaited_with(
+        f"/repos/{app.owner}/{app.repo}/installation",
+        accept="application/vnd.github+json",
+        jwt=jwt,
+    )
+
+    # Execute
+    mock_gh.getitem.reset_mock()
+    actual_installation_id = await app.get_installation_id()
+
+    # Verify: second call returns cached result
+    assert actual_installation_id == installation_id
+    mock_gh.getitem.assert_not_awaited()
+
+
+@mock.patch("hubcast.auth.github.gha")
+@mock.patch("hubcast.auth.github.gh_aiohttp.GitHubAPI")
+async def test_authenticate_installation(
+    MockGitHubAPI,
+    mock_gha,
+    app_factory,
+    github_config,
+    jwt,
+    installation_id,
+    iso_8601_timestamp,
+    access_token,
+    app_id,
+    private_key,
+):
+    # Setup
+    mock_gha.get_jwt.return_value = jwt
+    mock_gh = MockGitHubAPI.return_value
+    mock_gh.post = mock.AsyncMock()
+    mock_gh.post.return_value = {
+        "token": access_token,
+        "expires_at": iso_8601_timestamp
+    }
+    mock_gh.getitem = mock.AsyncMock()
+    mock_gh.getitem.return_value = {"id": installation_id}
+    app = app_factory(github_config)
+
+    # Execute
+    actual_access_token = await app.authenticate_installation()
+
+    # Verify
+    assert actual_access_token == access_token
+    mock_gh.post.assert_awaited_with(
+        "app/installations/{installation_id}/access_tokens",
+        {"installation_id": installation_id},
+        data=b"",
+        accept="application/vnd.github.machine-man-preview+json",
+        jwt=jwt,
+    )

--- a/hubcast/tests/test_github_auth.py
+++ b/hubcast/tests/test_github_auth.py
@@ -82,7 +82,9 @@ async def test_get_installation_id(
     hubcast_repo = hubcast_repo_factory(config)
 
     # Execute
-    actual_installation_id = await get_installation_id(mock.Mock(), hubcast_repo.github_config)
+    actual_installation_id = await get_installation_id(
+        mock.Mock(), hubcast_repo.github_config
+    )
 
     # Verify
     assert actual_installation_id == installation_id
@@ -121,7 +123,9 @@ async def test_authenticate_installation(
     hubcast_repo.github_config.installation_id = installation_id
 
     # Execute
-    actual_access_token = await authenticate_installation(mock.Mock(), hubcast_repo.github_config)
+    actual_access_token = await authenticate_installation(
+        mock.Mock(), hubcast_repo.github_config
+    )
 
     # Verify
     assert actual_access_token == access_token

--- a/hubcast/tests/test_github_auth.py
+++ b/hubcast/tests/test_github_auth.py
@@ -169,7 +169,7 @@ async def test_authenticate_installation(
     mock_gh.post = mock.AsyncMock()
     mock_gh.post.return_value = {
         "token": access_token,
-        "expires_at": iso_8601_timestamp
+        "expires_at": iso_8601_timestamp,
     }
     mock_gh.getitem = mock.AsyncMock()
     mock_gh.getitem.return_value = {"id": installation_id}

--- a/hubcast/tests/test_github_route.py
+++ b/hubcast/tests/test_github_route.py
@@ -20,6 +20,11 @@ def pr_event_factory():
 
 
 @pytest.fixture
+def hubcast_repo(hubcast_repo_factory, hubcast_config):
+    return hubcast_repo_factory(config=hubcast_config)
+
+
+@pytest.fixture
 def mock_git_config():
     return {"repo_path": "/"}
 
@@ -30,12 +35,14 @@ def mock_git():
         yield MockGit.return_value
 
 
-async def test_github_sync_pr(mock_git_config, mock_git, pr_number, pr_event_factory):
+async def test_github_sync_pr(
+    mock_git_config, mock_git, hubcast_repo, pr_number, pr_event_factory
+):
     # Setup
     event = pr_event_factory(pr_number)
 
     # Execute
-    await github.sync_pr(event, mock.Mock(), mock_git_config)
+    await github.sync_pr(event, hubcast_repo, mock.Mock())
 
     # Verify
     mock_git.assert_has_calls(
@@ -46,12 +53,14 @@ async def test_github_sync_pr(mock_git_config, mock_git, pr_number, pr_event_fac
     )
 
 
-async def test_github_remove_pr(mock_git_config, mock_git, pr_number, pr_event_factory):
+async def test_github_remove_pr(
+    mock_git_config, mock_git, hubcast_repo, pr_number, pr_event_factory
+):
     # Setup
     event = pr_event_factory(pr_number)
 
     # Execute
-    await github.remove_pr(event, mock.Mock(), mock_git_config)
+    await github.remove_pr(event, hubcast_repo, mock.Mock())
 
     # Verify
     mock_git.assert_called_once_with(f"push -d gitlab refs/heads/pr-{pr_number}")

--- a/hubcast/utils/git.py
+++ b/hubcast/utils/git.py
@@ -5,6 +5,11 @@ from attrs import define, field
 
 
 @define
+class GitException(Exception):
+    message: str = field()
+
+
+@define
 class Git:
     config: dict = field(factory=dict)
     base_path: str = field()
@@ -15,11 +20,15 @@ class Git:
 
     def __call__(self, args: str) -> subprocess.CompletedProcess:
         """Executes a git command on the host system."""
-        result = subprocess.run(
-            ["git", "-C", f"{self.base_path}"] + shlex.split(args),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            check=True,
-        )
-        return result
+        try:
+            result = subprocess.run(
+                ["git", "-C", f"{self.base_path}"] + shlex.split(args),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=True,
+            )
+            return result
+        except subprocess.CalledProcessError as e:
+            # TODO: Custom exception types by message
+            raise GitException(f"Command {e.cmd} failed with '{e.output}'")

--- a/hubcast/utils/git.py
+++ b/hubcast/utils/git.py
@@ -1,17 +1,29 @@
 import os
+import shlex
 import subprocess
-
-# get configuration from environment.
-GIT_REPO_PATH = os.environ.get("HC_GIT_REPO_PATH")
+from attrs import define, field
 
 
-def git(args):
-    """Executes a git command on the host system."""
-    result = subprocess.run(
-        ["git", "-C", f"{GIT_REPO_PATH}"] + args.split(),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=True,
-    )
-    return result
+@define
+class Git:
+    config: dict = field()
+    repo_path: str = field()
+
+    @config.default
+    def _config(self) -> dict:
+        return {}
+
+    @repo_path.default
+    def _repo_path(self) -> str:
+        return self.config.get("repo_path", os.getcwd())
+
+    def __call__(self, args: str) -> subprocess.CompletedProcess:
+        """Executes a git command on the host system."""
+        result = subprocess.run(
+            ["git", "-C", f"{self.repo_path}"] + shlex.split(args),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=True,
+        )
+        return result

--- a/hubcast/utils/git.py
+++ b/hubcast/utils/git.py
@@ -6,21 +6,17 @@ from attrs import define, field
 
 @define
 class Git:
-    config: dict = field()
-    repo_path: str = field()
+    config: dict = field(factory=dict)
+    base_path: str = field()
 
-    @config.default
-    def _config(self) -> dict:
-        return {}
-
-    @repo_path.default
-    def _repo_path(self) -> str:
-        return self.config.get("repo_path", os.getcwd())
+    @base_path.default
+    def _base_path(self) -> str:
+        return self.config.get("base_path", os.getcwd())
 
     def __call__(self, args: str) -> subprocess.CompletedProcess:
         """Executes a git command on the host system."""
         result = subprocess.run(
-            ["git", "-C", f"{self.repo_path}"] + shlex.split(args),
+            ["git", "-C", f"{self.base_path}"] + shlex.split(args),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ maintainers = [
 keywords = ["github", "gitlab", "mirroring", "ci"]
 dependencies = [
     "aiohttp",
+    "attrs",
+    "dynaconf",
     "cachetools",
     "gidgethub",
     "gidgetlab",

--- a/settings.toml
+++ b/settings.toml
@@ -6,7 +6,7 @@ dynaconf_merge = true
 port = 8080
 
 [default.git]
-repo_path = "/tmp"
+base_path = "/tmp"
 
 [default.github]
 repo = ""

--- a/settings.toml
+++ b/settings.toml
@@ -8,15 +8,21 @@ port = 8080
 [default.git]
 base_path = "/tmp"
 
+# TODO: this config will go away once we migrate to managing multiple repos
+[default.repo]
+name = ""
+
 [default.github]
-repo = ""
+url = ""
 app_id = ""
 private_key_path = ""
 # NOTE: these settings will transition elsewhere once we migrate to managing multiple repos
 requester = ""
-secret = ""
 check_name = ""
+secret = ""
 
 [default.gitlab]
-repo = ""
+url = ""
+requester = ""
 access_token = ""
+secret = ""

--- a/settings.toml
+++ b/settings.toml
@@ -1,0 +1,22 @@
+dynaconf_merge = true
+
+[default]
+
+[default.hubcast]
+port = 8080
+
+[default.git]
+repo_path = "/tmp"
+
+[default.github]
+repo = ""
+app_id = ""
+private_key_path = ""
+# NOTE: these settings will transition elsewhere once we migrate to managing multiple repos
+requester = ""
+secret = ""
+check_name = ""
+
+[default.gitlab]
+repo = ""
+access_token = ""

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,7 +7,9 @@ spack:
   specs:
   - python
   - py-aiohttp
+  - py-attrs
   - py-cachetools
+  - py-dynaconf
   - py-gidgethub
   - py-gidgetlab
   - py-pytest


### PR DESCRIPTION
While `dynaconf` would technically also support the same previous behavior, consolidating config into `__main__` and passing it along required some amount of refactor.

Some highlights:

In the course of refactoring, I've also positioned `hubcast` to eventually support processing multiple repos from a single `hubcast` server:
- Hubcast operations are now performed on `HubcastRepo` which contains the source and sink GitHub and GitLab config; many `HubcastRepos` can be housed in `HubcastRepoCache`
- Git repo storage is now prefixed by the name of the repo e.g. `LLNL/hubcast` would have it's `git` repo stored at `/git_base_path/hubcast`

Added the [`attrs` library](https://www.attrs.org/en/stable/index.html) to trim some class boilerplate, clarify types, and leverage default methods for caching.

I've configured `dynaconf` with a custom prefix `HC`. All settings in `settings.toml` can also be configured from the environment similar to how they were done previously (see [dynaconf env docs](https://www.dynaconf.com/envvars/) for more details). Here's a simple example:

```bash
(venv) thomas@himitsu hubcast % HC_GITHUB__REPO="https://github.com/LLNL/hubcast.git" python 
>>> from hubcast.config import settings
>>> settings.github.repo
'https://github.com/LLNL/hubcast.git'
```

At time of writing I still need to:
- [x] Migrate `hubcast.gitlab` to accept config
- [x] Migrate `hubcast.routes.gitlab` to accept config
- [ ] Update `README` to reference new configuration mechanism and slightly different naming

resolves: #19 