### PR TITLE
docs: add info on basic account map

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,6 +56,11 @@ export HC_GL_SECRET=""
 export HC_GL_REQUESTER=""
 
 #------------------------------------------------------------------------
+# Account Map Settings
+#------------------------------------------------------------------------
+export HC_ACCOUNT_MAP_PATH="users.yml"
+
+#------------------------------------------------------------------------
 # General Bot Settings
 #------------------------------------------------------------------------
 # Port for hubcast to listen on.
@@ -176,6 +181,25 @@ export HC_GL_SECRET=""
 
 # GitLab User to act on the behalf of.
 export HC_GL_REQUESTER=""
+```
+
+### Creating a Account Map Document
+Lastly we'll need to create a simple account map to map GitHub to GitLab users.
+
+##### .env
+```bash
+#------------------------------------------------------------------------
+# Account Map Settings
+#------------------------------------------------------------------------
+export HC_ACCOUNT_MAP_PATH="users.yml"
+```
+
+##### users.yml
+```yaml
+Users:
+  github_user1: gitlab_user1
+  github_user2: gitlab_user2
+  ...
 ```
 
 ### Finishing Up

--- a/hubcast/__main__.py
+++ b/hubcast/__main__.py
@@ -53,7 +53,7 @@ def main():
     if port is not None:
         port = int(port)
 
-    account_map_path = os.environ.get("HC_ACCOUNT_FILE")
+    account_map_path = os.environ.get("HC_ACCOUNT_MAP_PATH")
 
     gh_app_id = os.environ.get("HC_GH_APP_IDENTIFIER")
     gh_privkey = os.environ.get("HC_GH_PRIVATE_KEY")


### PR DESCRIPTION
Adding information to the Getting Started docs on how to use the new account map functionality.