### PR TITLE
Check if branch is part of a PR using GH API rather than ls_remote 

### DIFF
--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -103,8 +103,9 @@ class GitHubClient:
 
             return config
 
-    async def getitem(self, url: str):
-        """GET response from arbitrary GitHub API URL"""
+    async def get_prs(self, branch=None):
+        """Returns a list of all open PR numbers; can be filtered by internal branches."""
+
         gh_token = await self.auth.authenticate_installation(
             self.repo_owner, self.repo_name
         )
@@ -112,17 +113,11 @@ class GitHubClient:
         async with aiohttp.ClientSession() as session:
             gh = gh_aiohttp.GitHubAPI(session, self.requester, oauth_token=gh_token)
 
-            return await gh.getitem(url)
-
-    async def get_prs(self, branch=None):
-        """Get all open PRs in the repository, can be filtered by internal branches."""
-
-        # https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
-        # default is open pull requests
-
-        url = f"/repos/{self.repo_owner}/{self.repo_name}/pulls"
-        if branch:
-            # head: filter pulls by head user or head organization and branch name
-            url = f"{url}?head={self.repo_owner}:{branch}"
-
-        return await self.getitem(url)
+            # https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
+            # default is open pull requests
+            url = f"/repos/{self.repo_owner}/{self.repo_name}/pulls"
+            if branch:
+                # head: filter pulls by head user or head organization and branch name
+                url = f"{url}?head={self.repo_owner}:{branch}"
+                prs_res = await gh.getitem(url)
+                return [pr["number"] for pr in prs_res]

--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -113,3 +113,16 @@ class GitHubClient:
             gh = gh_aiohttp.GitHubAPI(session, self.requester, oauth_token=gh_token)
 
             return await gh.getitem(url)
+
+    async def get_prs(self, branch=None):
+        """Get all open PRs in the repository, can be filtered by internal branches."""
+
+        # https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
+        # default is open pull requests
+
+        url = "/repos/{gh.repo_owner}/{gh.repo_name}/pulls"
+        if branch:
+            # head: filter pulls by head user or head organization and branch name
+            url = f"{url}?head={self.repo_owner}:{branch}"
+
+        return self.getitem(url)

--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -120,9 +120,9 @@ class GitHubClient:
         # https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
         # default is open pull requests
 
-        url = "/repos/{gh.repo_owner}/{gh.repo_name}/pulls"
+        url = f"/repos/{self.repo_owner}/{self.repo_name}/pulls"
         if branch:
             # head: filter pulls by head user or head organization and branch name
             url = f"{url}?head={self.repo_owner}:{branch}"
 
-        return self.getitem(url)
+        return await self.getitem(url)

--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -102,3 +102,14 @@ class GitHubClient:
                 raise InvalidConfigYAMLError()
 
             return config
+
+    async def getitem(self, url: str):
+        """GET response from arbitrary GitHub API URL"""
+        gh_token = await self.auth.authenticate_installation(
+            self.repo_owner, self.repo_name
+        )
+
+        async with aiohttp.ClientSession() as session:
+            gh = gh_aiohttp.GitHubAPI(session, self.requester, oauth_token=gh_token)
+
+            return await gh.getitem(url)

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -36,13 +36,7 @@ async def sync_branch(event, gh, gl, gl_user, *arg, **kwargs):
     target_ref = event.data["ref"]
 
     # skip branches from push events that are also pull requests
-    # https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
-    # head: filter pulls by head user or head organization and branch name
-    branch_prs = await gh.getitem(
-        f"/repos/{gh.repo_owner}/{gh.repo_name}/pulls?head={gh.repo_owner}:{target_ref}"
-    )
-
-    if len(branch_prs) > 0:
+    if await gh.get_prs(target_ref):
         return
 
     repo_config = await get_repo_config(gh, src_fullname, refresh=True)

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -36,9 +36,13 @@ async def sync_branch(event, gh, gl, gl_user, *arg, **kwargs):
     target_ref = event.data["ref"]
 
     # skip branches from push events that are also pull requests
-    gh_refs = await ls_remote(src_repo_url)
-    pull_refs = [gh_refs[ref] for ref in gh_refs if ref.startswith("refs/pull/")]
-    if want_sha in pull_refs:
+    # https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
+    # head: filter pulls by head user or head organization and branch name
+    branch_prs = await gh.getitem(
+        f"/repos/{gh.repo_owner}/{gh.repo_name}/pulls?head={gh.repo_owner}:{target_ref}"
+    )
+
+    if len(branch_prs) > 0:
         return
 
     repo_config = await get_repo_config(gh, src_fullname, refresh=True)

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -36,7 +36,7 @@ async def sync_branch(event, gh, gl, gl_user, *arg, **kwargs):
     target_ref = event.data["ref"]
 
     # skip branches from push events that are also pull requests
-    if await gh.get_prs(target_ref):
+    if await gh.get_prs(branch=target_ref):
         return
 
     repo_config = await get_repo_config(gh, src_fullname, refresh=True)


### PR DESCRIPTION
closes https://github.com/LLNL/hubcast/issues/126

for some reason, the refs fail to update in time for hubcast to respond
  to a push event. This checks the existence of a PR with the name of
  the branch that's been pushed via the GH API. I've tested that this
  works onsite.