### PR TITLE
Move the embedded Spack repository to v2 format

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   repos:
-  - $env/spack/repo
+  - $env/spack/spack_repo/hubcast
   specs:
   - py-pip
   - py-hubcast

--- a/spack/spack_repo/hubcast/packages/py_hubcast/package.py
+++ b/spack/spack_repo/hubcast/packages/py_hubcast/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.python import PythonPackage
+
 from spack.package import *
 
 

--- a/spack/spack_repo/hubcast/repo.yaml
+++ b/spack/spack_repo/hubcast/repo.yaml
@@ -1,3 +1,3 @@
 repo:
   namespace: 'hubcast'
-  api: v1.0
+  api: v2.0


### PR DESCRIPTION
Kinda all in the title. Moving the embedded repository format to v2 to follow the change in Spack develop.