### PR TITLE
Error when required configuration variables are not found

### DIFF
--- a/src/hubcast/__main__.py
+++ b/src/hubcast/__main__.py
@@ -7,19 +7,28 @@ from aiojobs.aiohttp import setup
 from hubcast.account_map.file import FileMap
 from hubcast.clients.github import GitHubClientFactory
 from hubcast.clients.gitlab import GitLabClientFactory
-from hubcast.config import Config
+from hubcast.config import Config, ConfigError
 from hubcast.web.github import GitHubHandler
 from hubcast.web.gitlab import GitLabHandler
 
 
+log = logging.getLogger(__name__)
+
+
 def main():
     app = web.Application()
-    conf = Config()
 
+    try:
+        conf = Config()
+    except ConfigError as e:
+        log.error(e)
+        sys.exit(1)
+
+    # error if we're unable to initialize an account map
     if conf.account_map_type == "file":
         account_map = FileMap(conf.account_map_path)
     else:
-        print("Error: No Account Map Type Found")
+        log.error(f"Error: Unknown Account Map Type: {conf.account_map_type}")
         sys.exit(1)
 
     gh_client_factory = GitHubClientFactory(

--- a/src/hubcast/__main__.py
+++ b/src/hubcast/__main__.py
@@ -11,7 +11,6 @@ from hubcast.config import Config, ConfigError
 from hubcast.web.github import GitHubHandler
 from hubcast.web.gitlab import GitLabHandler
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/hubcast/config.py
+++ b/src/hubcast/config.py
@@ -1,5 +1,4 @@
 import os
-
 from typing import Optional
 
 

--- a/src/hubcast/config.py
+++ b/src/hubcast/config.py
@@ -1,12 +1,18 @@
 import os
 
+from typing import Optional
+
+
+class ConfigError(Exception):
+    pass
+
 
 class Config:
     def __init__(self):
-        self.port = int(os.environ.get("HC_PORT") or 8080)
+        self.port = int(env_get("HC_PORT", default="8080"))
 
-        self.account_map_type = os.environ.get("HC_ACCOUNT_MAP_TYPE")
-        self.account_map_path = os.environ.get("HC_ACCOUNT_MAP_PATH")
+        self.account_map_type = env_get("HC_ACCOUNT_MAP_TYPE")
+        self.account_map_path = env_get("HC_ACCOUNT_MAP_PATH")
 
         self.gh = GitHubConfig()
         self.gl = GitLabConfig()
@@ -14,15 +20,23 @@ class Config:
 
 class GitHubConfig:
     def __init__(self):
-        self.app_id = os.environ.get("HC_GH_APP_IDENTIFIER")
-        self.privkey = os.environ.get("HC_GH_PRIVATE_KEY")
-        self.requester = os.environ.get("HC_GH_REQUESTER")
-        self.webhook_secret = os.environ.get("HC_GH_SECRET")
+        self.app_id = env_get("HC_GH_APP_IDENTIFIER")
+        self.privkey = env_get("HC_GH_PRIVATE_KEY")
+        self.requester = env_get("HC_GH_REQUESTER")
+        self.webhook_secret = env_get("HC_GH_SECRET")
 
 
 class GitLabConfig:
     def __init__(self):
-        self.instance_url = os.environ.get("HC_GL_URL")
-        self.access_token = os.environ.get("HC_GL_ACCESS_TOKEN")
-        self.webhook_secret = os.environ.get("HC_GL_SECRET")
-        self.callback_url = os.environ.get("HC_GL_CALLBACK_URL")
+        self.instance_url = env_get("HC_GL_URL")
+        self.access_token = env_get("HC_GL_ACCESS_TOKEN")
+        self.webhook_secret = env_get("HC_GL_SECRET")
+        self.callback_url = env_get("HC_GL_CALLBACK_URL")
+
+
+def env_get(key: str, default: Optional[str] = None) -> str:
+    value = os.environ.get(key) or default
+    if not value:
+        raise ConfigError(f"Required environment variable not found: {key}")
+
+    return value


### PR DESCRIPTION
Closes #130.

Still a pretty lightweight solution we might want to flush out, but this supports erroring out when environment variables we expect don't exist.