### PR TITLE
Add link to Gitlab pipeline URL to Github check status

### DIFF
--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -34,12 +34,11 @@ class GitHubClient:
         self.repo_owner = repo_owner
         self.repo_name = repo_name
 
-    async def set_check_status(self, ref: str, check_name: str, status: str):
+    async def set_check_status(
+        self, ref: str, check_name: str, status: str, details_url: str
+    ):
         # construct upload payload
-        payload = {
-            "name": check_name,
-            "head_sha": ref,
-        }
+        payload = {"name": check_name, "head_sha": ref, "details_url": details_url}
 
         # for success and failure status write out a conclusion
         if status in ("success", "failure", "cancelled"):

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -45,6 +45,7 @@ async def status_relay(event, gh, gh_check_name, *arg, **kwargs):
 
     # get status from event
     ci_status = event.data["object_attributes"]["status"]
+    pipeline_url = event.data["object_attributes"]["url"]
 
     # https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks#about-check-suites
     # https://docs.gitlab.com/api/pipelines/#list-project-pipelines -> status description
@@ -61,4 +62,4 @@ async def status_relay(event, gh, gh_check_name, *arg, **kwargs):
     else:
         status = ci_status
 
-    await gh.set_check_status(ref, gh_check_name, status)
+    await gh.set_check_status(ref, gh_check_name, status, pipeline_url)


### PR DESCRIPTION
Example: https://github.com/cmelone/hubcast-test/pull/1/checks?check_run_id=42994357089

Using the [check-run](https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run) API, add a link to the Gitlab pipeline for the check associated with the ref. If the pipeline is canceled, retried, or failed, it will update.

While the [commit status](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status) API allows for a one-click solution within the checks table of a PR, it's not as flexible as using a check.