### PR TITLE
Add logging configuration and more error handling

### DIFF
--- a/logging_config.json
+++ b/logging_config.json
@@ -1,0 +1,38 @@
+{
+    "version": 1,
+    "disable_existing_loggers": false,
+    "formatters": {
+        "default": {
+            "()": "hubcast.logging.HubcastConsoleFormatter",
+            "format": "[%(asctime)s] %(levelname)s %(name)s: %(message)s",
+            "datefmt": "%Y-%m-%dT%H:%M:%S%z"
+        },
+        "json": {
+            "()": "hubcast.logging.HubcastJSONFormatter",
+            "fmt_keys": {
+                "level": "levelname",
+                "message": "message",
+                "timestamp": "timestamp",
+                "logger": "name"
+            }
+        }
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "default",
+            "stream": "ext://sys.stdout"
+        },
+        "json_stdout": {
+            "class": "logging.StreamHandler",
+            "formatter": "json",
+            "stream": "ext://sys.stdout"
+        }
+    },
+    "root": {
+        "level": "DEBUG",
+        "handlers": [
+            "json_stdout"
+        ]
+    }
+}

--- a/src/hubcast/__main__.py
+++ b/src/hubcast/__main__.py
@@ -27,9 +27,20 @@ def main():
         sys.exit(1)
 
     if os.path.exists(conf.logging_config_path):
-        with open(conf.logging_config_path) as f:
-            logging_config = json.load(f)
-        logging.config.dictConfig(logging_config)
+        try:
+            with open(conf.logging_config_path) as f:
+                logging_config = json.load(f)
+            logging.config.dictConfig(logging_config)
+        except (
+            json.decoder.JSONDecodeError,
+            # calls to dictConfig will raise the following exceptions (cf stdlib docs):
+            ValueError,
+            TypeError,
+            AttributeError,
+            ImportError,
+        ):
+            log.exception("Error loading logging config")
+            sys.exit(1)
     else:
         logging.basicConfig(level=logging.INFO)
 

--- a/src/hubcast/__main__.py
+++ b/src/hubcast/__main__.py
@@ -22,8 +22,8 @@ def main():
 
     try:
         conf = Config()
-    except ConfigError:
-        log.exception("Error loading Hubcast config")
+    except ConfigError as exc:
+        log.error(exc)
         sys.exit(1)
 
     if os.path.exists(conf.logging_config_path):

--- a/src/hubcast/account_map/file.py
+++ b/src/hubcast/account_map/file.py
@@ -1,11 +1,12 @@
-import logging
 from typing import Dict, Union
 
 import yaml
 
 from .abc import AccountMap
 
-log = logging.getLogger(__name__)
+
+class FileMapError(Exception):
+    pass
 
 
 class FileMap(AccountMap):
@@ -37,9 +38,9 @@ class FileMap(AccountMap):
                 data = yaml.safe_load(f)
                 self.users = data["Users"]
         except FileNotFoundError:
-            log.error("Account map file not found", extra={"path": path})
+            raise FileMapError(f"File map not found. path={path}")
         except yaml.YAMLError:
-            log.exception("Failed to parse file map YAML", extra={"path": path})
+            raise FileMapError(f"Failed to parse file map. path={path}")
 
     def __call__(self, github_user: str) -> Union[str, None]:
         """

--- a/src/hubcast/account_map/file.py
+++ b/src/hubcast/account_map/file.py
@@ -1,8 +1,11 @@
+import logging
 from typing import Dict, Union
 
 import yaml
 
 from .abc import AccountMap
+
+log = logging.getLogger(__name__)
 
 
 class FileMap(AccountMap):
@@ -29,12 +32,14 @@ class FileMap(AccountMap):
         """
         self.path = path
 
-        with open(path, "r") as f:
-            try:
+        try:
+            with open(path, "r") as f:
                 data = yaml.safe_load(f)
                 self.users = data["Users"]
-            except yaml.YAMLError as exc:
-                print(exc)
+        except FileNotFoundError:
+            log.error("Account map file not found", extra={"path": path})
+        except yaml.YAMLError:
+            log.exception("Failed to parse file map YAML", extra={"path": path})
 
     def __call__(self, github_user: str) -> Union[str, None]:
         """

--- a/src/hubcast/clients/github/auth.py
+++ b/src/hubcast/clients/github/auth.py
@@ -8,7 +8,7 @@ from gidgethub import aiohttp as gh_aiohttp
 
 # location for authenticated app to get a token for one of its installations
 # bandit thinks this is a hardcoded password, we ignore security checks on this line
-INSTALLATION_TOKEN_URL = "app/installations/{installation_id}/access_tokens"  # nosec B105
+INSTALLATION_TOKEN_URL = "/app/installations/{installation_id}/access_tokens"  # nosec B105
 
 log = logging.getLogger(__name__)
 
@@ -84,13 +84,7 @@ class GitHubAuthenticator:
                 )
                 self._id_dict[(owner, repo)] = result["id"]
 
-        try:
-            return self._id_dict[(owner, repo)]
-        except Exception:
-            log.error(
-                "Failed to get Github installation id",
-                extra={"repo_owner": owner, "repo_name": repo},
-            )
+        return self._id_dict[(owner, repo)]
 
     async def authenticate_installation(self, owner: str, repo: str) -> str:
         """
@@ -120,15 +114,7 @@ class GitHubAuthenticator:
                 token = result["token"]
                 return (expires, token)
 
-        try:
-            return await self._tokens.get_token(
-                installation_id, renew_installation_token
-            )
-        except Exception:
-            log.error(
-                "Failed to authenticate Github app installation",
-                extra={"installation_id": installation_id},
-            )
+        return await self._tokens.get_token(installation_id, renew_installation_token)
 
     def parse_isotime(self, timestr: str) -> int:
         """Convert UTC ISO 8601 time stamp to seconds in epoch"""
@@ -149,10 +135,4 @@ class GitHubAuthenticator:
             # gidgethub JWT's expire after 10 minutes (you cannot change it)
             return (now + 10 * 60), jwt
 
-        try:
-            return await self._tokens.get_token("JWT", renew_jwt)
-        except Exception:
-            log.error(
-                "Failed to generate Github JWT. Check validity of HC_GH_PRIVATE_KEY.",
-                extra={"github_app_id": self.app_id},
-            )
+        return await self._tokens.get_token("JWT", renew_jwt)

--- a/src/hubcast/clients/github/auth.py
+++ b/src/hubcast/clients/github/auth.py
@@ -133,7 +133,7 @@ class GitHubAuthenticator:
         except Exception:
             log.error(
                 "Failed to authenticate Github app installation",
-                {"installation_id": installation_id},
+                extra={"installation_id": installation_id},
             )
 
     def parse_isotime(self, timestr: str) -> int:

--- a/src/hubcast/clients/github/auth.py
+++ b/src/hubcast/clients/github/auth.py
@@ -99,13 +99,7 @@ class GitHubAuthenticator:
         token from github, if necessary.
         """
 
-        try:
-            installation_id = await self.get_installation_id(owner, repo)
-        except Exception:
-            log.error(
-                "Failed to get Github installation ID",
-                extra={"repo_owner": owner, "repo_name": repo},
-            )
+        installation_id = await self.get_installation_id(owner, repo)
 
         async def renew_installation_token():
             async with aiohttp.ClientSession() as session:

--- a/src/hubcast/clients/github/auth.py
+++ b/src/hubcast/clients/github/auth.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from typing import Awaitable, Callable, Tuple
 
@@ -9,8 +8,6 @@ from gidgethub import aiohttp as gh_aiohttp
 # location for authenticated app to get a token for one of its installations
 # bandit thinks this is a hardcoded password, we ignore security checks on this line
 INSTALLATION_TOKEN_URL = "/app/installations/{installation_id}/access_tokens"  # nosec B105
-
-log = logging.getLogger(__name__)
 
 
 class TokenCache:

--- a/src/hubcast/clients/github/auth.py
+++ b/src/hubcast/clients/github/auth.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from typing import Awaitable, Callable, Tuple
 
@@ -8,6 +9,8 @@ from gidgethub import aiohttp as gh_aiohttp
 # location for authenticated app to get a token for one of its installations
 # bandit thinks this is a hardcoded password, we ignore security checks on this line
 INSTALLATION_TOKEN_URL = "app/installations/{installation_id}/access_tokens"  # nosec B105
+
+log = logging.getLogger(__name__)
 
 
 class TokenCache:
@@ -81,7 +84,13 @@ class GitHubAuthenticator:
                 )
                 self._id_dict[(owner, repo)] = result["id"]
 
-        return self._id_dict[(owner, repo)]
+        try:
+            return self._id_dict[(owner, repo)]
+        except Exception:
+            log.error(
+                "Failed to get Github installation id",
+                extra={"repo_owner": owner, "repo_name": repo},
+            )
 
     async def authenticate_installation(self, owner: str, repo: str) -> str:
         """
@@ -89,7 +98,14 @@ class GitHubAuthenticator:
         Renew the JWT if necessary, then use it to get an installation access
         token from github, if necessary.
         """
-        installation_id = await self.get_installation_id(owner, repo)
+
+        try:
+            installation_id = await self.get_installation_id(owner, repo)
+        except Exception:
+            log.error(
+                "Failed to get Github installation ID",
+                extra={"repo_owner": owner, "repo_name": repo},
+            )
 
         async def renew_installation_token():
             async with aiohttp.ClientSession() as session:
@@ -110,7 +126,15 @@ class GitHubAuthenticator:
                 token = result["token"]
                 return (expires, token)
 
-        return await self._tokens.get_token(installation_id, renew_installation_token)
+        try:
+            return await self._tokens.get_token(
+                installation_id, renew_installation_token
+            )
+        except Exception:
+            log.error(
+                "Failed to authenticate Github app installation",
+                {"installation_id": installation_id},
+            )
 
     def parse_isotime(self, timestr: str) -> int:
         """Convert UTC ISO 8601 time stamp to seconds in epoch"""
@@ -131,4 +155,10 @@ class GitHubAuthenticator:
             # gidgethub JWT's expire after 10 minutes (you cannot change it)
             return (now + 10 * 60), jwt
 
-        return await self._tokens.get_token("JWT", renew_jwt)
+        try:
+            return await self._tokens.get_token("JWT", renew_jwt)
+        except Exception:
+            log.error(
+                "Failed to generate Github JWT. Check validity of HC_GH_PRIVATE_KEY.",
+                extra={"github_app_id": self.app_id},
+            )

--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -84,9 +84,13 @@ class GitHubClient:
 
             try:
                 config = yaml.safe_load(config_str)
-            except yaml.YAMLError as exc:
-                log.error(
-                    f"[{self.repo_owner}/{self.repo_name}]: Unable to parse config: {exc}"
+            except yaml.YAMLError:
+                log.exception(
+                    "Failed to parse Hubcast repo config",
+                    extra={
+                        "repo_owner": self.repo_owner,
+                        "repo_name": self.repo_name,
+                    },
                 )
                 raise InvalidConfigYAMLError()
 

--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -1,12 +1,8 @@
-import logging
-
 import aiohttp
 import yaml
 from gidgethub import aiohttp as gh_aiohttp
 
 from .auth import GitHubAuthenticator
-
-log = logging.getLogger(__name__)
 
 
 class InvalidConfigYAMLError(Exception):
@@ -85,14 +81,9 @@ class GitHubClient:
             try:
                 config = yaml.safe_load(config_str)
             except yaml.YAMLError:
-                log.exception(
-                    "Failed to parse Hubcast repo config",
-                    extra={
-                        "repo_owner": self.repo_owner,
-                        "repo_name": self.repo_name,
-                    },
+                raise InvalidConfigYAMLError(
+                    f"Failed to parse repo config. repo_owner={self.repo_owner} repo_name={self.repo_name}"
                 )
-                raise InvalidConfigYAMLError()
 
             return config
 

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -1,3 +1,4 @@
+import logging
 import urllib.parse
 from typing import Dict
 
@@ -5,6 +6,8 @@ import aiohttp
 import gidgetlab.aiohttp
 
 from .auth import GitLabAuthenticator
+
+log = logging.getLogger(__name__)
 
 
 class GitLabClientFactory:
@@ -48,9 +51,15 @@ class GitLabClient:
         }
 
         async with aiohttp.ClientSession() as session:
-            gl = gidgetlab.aiohttp.GitLabAPI(
-                session, self.user, access_token=gl_token, url=self.instance_url
-            )
+            try:
+                gl = gidgetlab.aiohttp.GitLabAPI(
+                    session, self.user, access_token=gl_token, url=self.instance_url
+                )
+            except Exception:
+                logging.error(
+                    "Failed to authenticate Gitlab session. Verify access token.",
+                    extra={"user": self.user, "url": self.instance_url},
+                )
 
             existing_hook = None
 

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -1,4 +1,3 @@
-import logging
 import urllib.parse
 from typing import Dict
 
@@ -6,8 +5,6 @@ import aiohttp
 import gidgetlab.aiohttp
 
 from .auth import GitLabAuthenticator
-
-log = logging.getLogger(__name__)
 
 
 class GitLabClientFactory:
@@ -51,17 +48,9 @@ class GitLabClient:
         }
 
         async with aiohttp.ClientSession() as session:
-            try:
-                gl = gidgetlab.aiohttp.GitLabAPI(
-                    session, self.user, access_token=gl_token, url=self.instance_url
-                )
-            except Exception:
-                logging.error(
-                    "Failed to authenticate GitLab session. Verify access token.",
-                    extra={"user": self.user, "url": self.instance_url},
-                )
-
-                return
+            gl = gidgetlab.aiohttp.GitLabAPI(
+                session, self.user, access_token=gl_token, url=self.instance_url
+            )
 
             existing_hook = None
 

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -57,9 +57,11 @@ class GitLabClient:
                 )
             except Exception:
                 logging.error(
-                    "Failed to authenticate Gitlab session. Verify access token.",
+                    "Failed to authenticate GitLab session. Verify access token.",
                     extra={"user": self.user, "url": self.instance_url},
                 )
+
+                return
 
             existing_hook = None
 

--- a/src/hubcast/config.py
+++ b/src/hubcast/config.py
@@ -12,6 +12,7 @@ class Config:
 
         self.account_map_type = env_get("HC_ACCOUNT_MAP_TYPE")
         self.account_map_path = env_get("HC_ACCOUNT_MAP_PATH")
+        self.logging_config_path = env_get("HC_LOGGING_CONFIG_PATH")
 
         self.gh = GitHubConfig()
         self.gl = GitLabConfig()

--- a/src/hubcast/logging.py
+++ b/src/hubcast/logging.py
@@ -1,0 +1,111 @@
+import datetime as dt
+import json
+import logging
+
+LOG_RECORD_BUILTIN_ATTRS = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "module",
+        "msecs",
+        "message",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "thread",
+        "threadName",
+        "taskName",
+    }
+)
+
+
+class HubcastJSONFormatter(logging.Formatter):
+    def __init__(self, *, fmt_keys=None):
+        super().__init__()
+        self.fmt_keys = fmt_keys or {}
+
+    def format(self, record: logging.LogRecord) -> str:
+        record_dict = record.__dict__
+
+        # fields that are only included
+        log_data = {
+            "timestamp": dt.datetime.fromtimestamp(
+                record.created, tz=dt.timezone.utc
+            ).isoformat(timespec="microseconds"),
+            "level": record.levelname,
+            "logger": record.name,
+        }
+
+        # exclude suppressed messages
+        if not (record.name == "aiohttp.access" and "message" in self.fmt_keys):
+            log_data["message"] = record.getMessage()
+
+        # add exception info
+        if record.exc_info:
+            log_data["exc_info"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            log_data["stack_info"] = self.formatStack(record.stack_info)
+
+        # map additional fields via fmt_keys
+        for output_key, attr_name in self.fmt_keys.items():
+            if output_key in log_data:
+                continue  # already populated
+            if hasattr(record, attr_name):
+                log_data[output_key] = getattr(record, attr_name)
+
+        # add any user-defined extra fields (from logger(..., extra={...}))
+        for key, val in record_dict.items():
+            if key not in LOG_RECORD_BUILTIN_ATTRS and key not in log_data:
+                log_data[key] = val
+
+        return json.dumps(log_data, default=str)
+
+
+class HubcastConsoleFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        logger = logging.getLogger(record.name)
+        show_traceback = logger.isEnabledFor(logging.DEBUG)
+
+        # temporarily suppress traceback if we're not in DEBUG mode
+        original_exc_info = record.exc_info
+        if not show_traceback:
+            record.exc_info = None
+
+        # format the base log line
+        try:
+            base = super().format(record)
+        finally:
+            # always restore exc_info after formatting
+            record.exc_info = original_exc_info
+
+        # skip extras for aiohttp.access since they provide redundant info
+        if record.name == "aiohttp.access":
+            return base
+
+        # add any user-defined extra fields
+        extras = {
+            k: v
+            for k, v in record.__dict__.items()
+            if k not in LOG_RECORD_BUILTIN_ATTRS
+        }
+
+        # format extras
+
+        if extras:
+            extra_str = " " + " ".join(f"{k}={v}" for k, v in extras.items())
+        else:
+            extra_str = ""
+
+        return base + extra_str

--- a/src/hubcast/web/github/handler.py
+++ b/src/hubcast/web/github/handler.py
@@ -19,42 +19,31 @@ class GitHubHandler:
         self.gl = gitlab_client_factory
 
     async def handle(self, request):
-        try:
-            # read the GitHub webhook payload
-            body = await request.read()
-            event = sansio.Event.from_http(
-                request.headers, body, secret=self.webhook_secret
-            )
+        # read the GitHub webhook payload
+        body = await request.read()
+        event = sansio.Event.from_http(
+            request.headers, body, secret=self.webhook_secret
+        )
 
-            log.info(
-                "GitHub webhook received",
-                extra={"event_type": event.event, "delivery_id": event.delivery_id},
-            )
+        log.info(
+            "GitHub webhook received",
+            extra={"event_type": event.event, "delivery_id": event.delivery_id},
+        )
 
-            try:
-                github_user = event.data["sender"]["login"]
-                gitlab_user = self.account_map(github_user)
-            except Exception:
-                log.exception("Failed to map GitHub user")
-                return web.Response(status=200)
+        github_user = event.data["sender"]["login"]
+        gitlab_user = self.account_map(github_user)
 
-            if gitlab_user is None:
-                log.info("Unauthorized GitHub user", extra={"github_user": github_user})
-                return web.Response(status=200)
-
-            gh_repo_owner = event.data["repository"]["owner"]["login"]
-            gh_repo = event.data["repository"]["name"]
-
-            gh = self.gh.create_client(gh_repo_owner, gh_repo)
-            gl = self.gl.create_client(gitlab_user)
-
-            await spawn(request, router.dispatch(event, gh, gl, gitlab_user))
-
-            # return a "Success"
+        if gitlab_user is None:
+            log.info("Unauthorized GitHub user", extra={"github_user": github_user})
             return web.Response(status=200)
-        except Exception:
-            # this catches errors related to GitHub API calls
-            log.exception(
-                "Failed to handle GitHub webhook",
-            )
-            return web.Response(status=500)
+
+        gh_repo_owner = event.data["repository"]["owner"]["login"]
+        gh_repo = event.data["repository"]["name"]
+
+        gh = self.gh.create_client(gh_repo_owner, gh_repo)
+        gl = self.gl.create_client(gitlab_user)
+
+        await spawn(request, router.dispatch(event, gh, gl, gitlab_user))
+
+        # return a "Success"
+        return web.Response(status=200)

--- a/src/hubcast/web/github/handler.py
+++ b/src/hubcast/web/github/handler.py
@@ -26,17 +26,20 @@ class GitHubHandler:
                 request.headers, body, secret=self.webhook_secret
             )
 
-            log.info(f"GH delivery ID: {event.delivery_id}")
+            log.info(
+                "GitHub webhook received",
+                extra={"event_type": event.event, "delivery_id": event.delivery_id},
+            )
 
             try:
                 github_user = event.data["sender"]["login"]
                 gitlab_user = self.account_map(github_user)
-            except Exception as exc:
-                log.error(exc)
+            except Exception:
+                log.exception("Failed to map GitHub user")
                 return web.Response(status=200)
 
             if gitlab_user is None:
-                log.info(f"Unauthorized GitHub User: {github_user}")
+                log.info("Unauthorized GitHub user", extra={"github_user": github_user})
                 return web.Response(status=200)
 
             gh_repo_owner = event.data["repository"]["owner"]["login"]
@@ -49,6 +52,9 @@ class GitHubHandler:
 
             # return a "Success"
             return web.Response(status=200)
-
         except Exception:
+            # this catches errors related to GitHub API calls
+            log.exception(
+                "Failed to handle GitHub webhook",
+            )
             return web.Response(status=500)

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -32,7 +32,6 @@ class GitHubRouter(routing.Router):
 
 
 router = GitHubRouter()
-log = logging.getLogger(__name__)
 
 
 # -----------------------------------

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -1,9 +1,12 @@
+import logging
 from typing import Dict
 
 from hubcast.clients.github import GitHubClient
 from hubcast.repos.config import RepoConfig
+from src.hubcast.clients.github.client import InvalidConfigYAMLError
 
 config_cache = dict()
+log = logging.getLogger(__name__)
 
 
 def create_config(fullname: str, data: Dict) -> RepoConfig:
@@ -18,7 +21,11 @@ async def get_repo_config(gh: GitHubClient, fullname: str, refresh: bool = False
     if fullname in config_cache and not refresh:
         config = config_cache[fullname]
     else:
-        data = await gh.get_repo_config()
+        try:
+            data = await gh.get_repo_config()
+        except InvalidConfigYAMLError:
+            log.exception("Repo config parse failed")
+
         config = create_config(fullname, data)
         config_cache[fullname] = config
 

--- a/src/hubcast/web/gitlab/handler.py
+++ b/src/hubcast/web/gitlab/handler.py
@@ -1,10 +1,9 @@
 import logging
-import sys
-import traceback
 
 from aiohttp import web
 from aiojobs.aiohttp import spawn
 from gidgetlab import sansio
+from gidgetlab.exceptions import ValidationFailure
 
 from hubcast.clients.github import GitHubClientFactory
 
@@ -19,14 +18,13 @@ class GitLabHandler:
         self.github_client_factory = github_client_factory
 
     async def handle(self, request):
-        pass
         try:
             # read the GitLab webhook payload
             body = await request.read()
             event = sansio.Event.from_http(
                 request.headers, body, secret=self.webhook_secret
             )
-            log.info(f"GL delivery ID: {event.event}")
+            log.info("GitLab webhook received", extra={"event_type": event.event})
 
             # get coorisponding GitHub repo owner and name from event
             # request variables
@@ -46,7 +44,13 @@ class GitLabHandler:
 
             # return a "Success"
             return web.Response(status=200)
+        except ValidationFailure:
+            log.exception(
+                "Failed to validate Gitlab webhook request",
+            )
+            return web.Response(status=500)
 
         except Exception:
-            traceback.print_exc(file=sys.stderr)
+            # this catches errors related to GitLab API calls
+            log.exception("Failed to handle GitLab webhook")
             return web.Response(status=500)

--- a/src/hubcast/web/gitlab/handler.py
+++ b/src/hubcast/web/gitlab/handler.py
@@ -51,6 +51,5 @@ class GitLabHandler:
             return web.Response(status=500)
 
         except Exception:
-            # this catches errors related to GitLab API calls
             log.exception("Failed to handle GitLab webhook")
             return web.Response(status=500)

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -1,6 +1,9 @@
+import logging
 from typing import Any
 
 from gidgetlab import routing, sansio
+
+log = logging.getLogger(__name__)
 
 
 class GitLabRouter(routing.Router):
@@ -27,7 +30,16 @@ class GitLabRouter(routing.Router):
                     if event_value in data_values:
                         found_callbacks.extend(data_values[event_value])
         for callback in found_callbacks:
-            await callback(event, *args, **kwargs)
+            try:
+                await callback(event, *args, **kwargs)
+            except Exception:
+                # this catches errors related to processing of webhook events
+                log.exception(
+                    "Failed to process GitLab webhook event",
+                    extra={
+                        "event_type": event.event,
+                    },
+                )
 
 
 router = GitLabRouter()


### PR DESCRIPTION
Adds the ability to configure log formatting, rotation policy, and other aspects that will be helpful when Hubcast is deployed in production. This PR builds upon and supersedes the work in #49.


We check `LC_LOGGING_CONFIG_PATH` for a JSON file (see `logging_config.json` for an example) that is loaded into logging's [`dictConfig`](https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig).

If this file isn't found, it will fall back to `logging.basicConfig(level=logging.INFO)`.

Here's some example output of the `console` handler in `DEBUG` mode:

```
[2025-06-16T14:24:53-0700] INFO __main__: Starting HTTP server
[2025-06-16T14:24:53-0700] DEBUG asyncio: Using selector: KqueueSelector
======== Running on http://0.0.0.0:8080 ========
(Press CTRL+C to quit)
[2025-06-16T14:25:00-0700] INFO hubcast.web.github.handler: GitHub webhook received event_type=push delivery_id=5b88ba9a-4af8-11f0-86e4-b383a13160d9
[2025-06-16T14:25:00-0700] INFO aiohttp.access: "POST /v1/events/src/github HTTP/1.1" 200 112 "-" "GitHub-Hookshot/fb6e15e"
[2025-06-16T14:25:00-0700] INFO hubcast.web.github.handler: GitHub webhook received event_type=check_suite delivery_id=5bd64800-4af8-11f0-876c-e4d119905397
[2025-06-16T14:25:00-0700] INFO aiohttp.access: "POST /v1/events/src/github HTTP/1.1" 200 112 "-" "GitHub-Hookshot/fb6e15e"
[2025-06-16T14:25:01-0700] INFO hubcast.web.github.handler: GitHub webhook received event_type=pull_request delivery_id=5bcecdf0-4af8-11f0-957b-2598edea53b5
[2025-06-16T14:25:01-0700] INFO aiohttp.access: "POST /v1/events/src/github HTTP/1.1" 200 112 "-" "GitHub-Hookshot/fb6e15e"
[2025-06-16T14:25:01-0700] INFO hubcast.web.gitlab.handler: GitLab webhook received event_type=Pipeline Hook
[2025-06-16T14:25:01-0700] INFO aiohttp.access: "POST /v1/events/dest/gitlab?gh_owner=cmelone&gh_repo=hubcast-test&gh_check=gitlab-ci HTTP/1.1" 200 112 "-" "GitLab/18.1.0-pre"
[2025-06-16T14:25:01-0700] INFO hubcast.web.github.routes: Mirroring refs repo=cmelone/hubcast-test from_sha=639805e4b5c49156fcf7d4b1f924192024ef6977 want_sha=124c9a1499abf4cb8eb78bd4657812adbfc9c316
```

`json_stdout` equivalent:

```
{"timestamp": "2025-06-16T21:24:14.685768+00:00", "level": "INFO", "logger": "__main__", "message": "Starting HTTP server"}
{"timestamp": "2025-06-16T21:24:14.685959+00:00", "level": "DEBUG", "logger": "asyncio", "message": "Using selector: KqueueSelector"}
======== Running on http://0.0.0.0:8080 ========
(Press CTRL+C to quit)
{"timestamp": "2025-06-16T21:24:23.989337+00:00", "level": "INFO", "logger": "hubcast.web.github.handler", "message": "GitHub webhook received", "event_type": "push", "delivery_id": "4601fd30-4af8-11f0-8be9-5d529e758a3b"}
{"timestamp": "2025-06-16T21:24:23.990084+00:00", "level": "INFO", "logger": "aiohttp.access", "first_request_line": "POST /v1/events/src/github HTTP/1.1", "response_status": 200, "response_size": 112, "request_header": {"Referer": "-", "User-Agent": "GitHub-Hookshot/fb6e15e"}}
{"timestamp": "2025-06-16T21:24:24.521227+00:00", "level": "INFO", "logger": "hubcast.web.github.handler", "message": "GitHub webhook received", "event_type": "pull_request", "delivery_id": "46145d90-4af8-11f0-839d-4c2c6ecab03a"}
{"timestamp": "2025-06-16T21:24:24.522205+00:00", "level": "INFO", "logger": "aiohttp.access", "first_request_line": "POST /v1/events/src/github HTTP/1.1", "response_status": 200, "response_size": 112, "request_header": {"Referer": "-", "User-Agent": "GitHub-Hookshot/fb6e15e"}}
{"timestamp": "2025-06-16T21:24:24.751648+00:00", "level": "INFO", "logger": "hubcast.web.github.handler", "message": "GitHub webhook received", "event_type": "check_suite", "delivery_id": "4651b4b0-4af8-11f0-8db1-ff6d9104c3de"}
{"timestamp": "2025-06-16T21:24:24.751952+00:00", "level": "INFO", "logger": "aiohttp.access", "first_request_line": "POST /v1/events/src/github HTTP/1.1", "response_status": 200, "response_size": 112, "request_header": {"Referer": "-", "User-Agent": "GitHub-Hookshot/fb6e15e"}}
{"timestamp": "2025-06-16T21:24:25.503347+00:00", "level": "INFO", "logger": "hubcast.web.github.routes", "message": "Mirroring refs", "repo": "cmelone/hubcast-test", "from_sha": "09613c00f15d083f92fcfdc23e11e9140053b351", "want_sha": "639805e4b5c49156fcf7d4b1f924192024ef6977"}
```

The JSON logs can be better ingested and filtered by external logging tools if necessary.

I added exception handlers to blocks where I encountered issues if env variables were misconfigured. The Gitlab and Github webhook handlers are also enclosed in try/except blocks to notify of generic issues. 


For errors, some will have simple messages. However, for the generic handlers where we aren't catching every issue, we call `log.exception(...)`.

If logging is in DEBUG mode, the console handler will print the stacktrace. The JSON handler will always store the stacktrace in the `exc_info` key.

I tried to err on the side of not over-logging events, but let me know if you want me to add/remove some of the logging.

---
closes #32 
closes #49