### PR TITLE
Support Gitlab instances for source repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Hubcast is an event driven synchronization application for bridging GitHub and GitLab to GitLab. It automates various workflow tasks and handles jobs like:
 
 - Syncing branches from GitHub to GitLab.
-- Synching branches from GitLab to GitLab.
+- Syncing branches from GitLab to GitLab.
 - Reporting CI job statuses back to GitHub from GitLab Workflow Runs.
 
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@
 
 </div>
 
-Hubcast is an event driven synchronization application for bridging GitHub and GitLab. It automates various workflow tasks and handles jobs like:
+Hubcast is an event driven synchronization application for bridging GitHub and GitLab to GitLab. It automates various workflow tasks and handles jobs like:
 
 - Syncing branches from GitHub to GitLab.
+- Synching branches from GitLab to GitLab.
 - Reporting CI job statuses back to GitHub from GitLab Workflow Runs.
 
 

--- a/src/hubcast/__main__.py
+++ b/src/hubcast/__main__.py
@@ -66,7 +66,7 @@ def main():
         conf.gl_dest.webhook_secret,
     )
 
-    if conf.src_service == "github":
+    if conf.src_forge == "github":
         src_client_factory = GitHubClientFactory(
             conf.gh_src.app_id, conf.gh_src.privkey, conf.gh_src.requester
         )
@@ -77,7 +77,7 @@ def main():
             dest_client_factory,
         )
 
-    elif conf.src_service == "gitlab":
+    elif conf.src_forge == "gitlab":
         src_client_factory = GitLabClientFactory(
             conf.gl_dest.instance_url,
             conf.gl_dest.requester,
@@ -105,7 +105,7 @@ def main():
 
     log.info("Starting HTTP server")
 
-    app.router.add_post(f"/v1/events/src/{conf.src_service}", src_handler.handle)
+    app.router.add_post(f"/v1/events/src/{conf.src_forge}", src_handler.handle)
     app.router.add_post("/v1/events/dest/gitlab", dest_handler.handle)
 
     setup(app)

--- a/src/hubcast/account_map/abc.py
+++ b/src/hubcast/account_map/abc.py
@@ -8,8 +8,8 @@ class AccountMap(ABC):
     """
 
     @abstractmethod
-    def __call__(self, src_user: str) -> Union[str, None]:
+    def __call__(self, src_forge_user: str) -> Union[str, None]:
         """
-        Return the corresponding gitlab_user for a given src_user if one exists.
+        Return the corresponding dest_forge_user for a given src_forge_user if one exists.
         """
         pass

--- a/src/hubcast/account_map/abc.py
+++ b/src/hubcast/account_map/abc.py
@@ -8,9 +8,8 @@ class AccountMap(ABC):
     """
 
     @abstractmethod
-    def __call__(self, github_user: str) -> Union[str, None]:
+    def __call__(self, src_user: str) -> Union[str, None]:
         """
-        Return the coorisponding gitlab_user for a given github_user if
-        one exists.
+        Return the corresponding gitlab_user for a given src_user if one exists.
         """
         pass

--- a/src/hubcast/account_map/file.py
+++ b/src/hubcast/account_map/file.py
@@ -29,7 +29,7 @@ class FileMap(AccountMap):
     def __init__(self, path: str):
         """
         Constructor, path to read from and generate a simple account
-        mapping between services (eg gitlab->gitlab or github->gitlab).
+        mapping between forges (eg gitlab->gitlab or github->gitlab).
         """
         self.path = path
 
@@ -42,8 +42,8 @@ class FileMap(AccountMap):
         except yaml.YAMLError:
             raise FileMapError(f"Failed to parse file map. path={path}")
 
-    def __call__(self, src_user: str) -> Union[str, None]:
+    def __call__(self, src_forge_user: str) -> Union[str, None]:
         """
-        Return the gitlab_user for a src_user if one exists.
+        Return the dest_forge_user for a src_forge_user if one exists.
         """
-        return self.users.get(src_user)
+        return self.users.get(src_forge_user)

--- a/src/hubcast/account_map/file.py
+++ b/src/hubcast/account_map/file.py
@@ -11,7 +11,7 @@ class FileMapError(Exception):
 
 class FileMap(AccountMap):
     """
-    A simple user map importing from a YAML file of the form.
+    A simple user map importing from a YAML file of the form:
 
     Users:
       github_user: gitlab_user
@@ -20,7 +20,7 @@ class FileMap(AccountMap):
     Attributes
     ----------
     path: str
-        A filepath to the users.yml defining a usermapping.
+        A filepath to the users.yml defining a user mapping.
     """
 
     path: str
@@ -29,7 +29,7 @@ class FileMap(AccountMap):
     def __init__(self, path: str):
         """
         Constructor, path to read from and generate a simple account
-        mapping between services.
+        mapping between services (eg gitlab->gitlab or github->gitlab).
         """
         self.path = path
 
@@ -42,8 +42,8 @@ class FileMap(AccountMap):
         except yaml.YAMLError:
             raise FileMapError(f"Failed to parse file map. path={path}")
 
-    def __call__(self, github_user: str) -> Union[str, None]:
+    def __call__(self, src_user: str) -> Union[str, None]:
         """
-        Return the gitlab_user for a github_user if one exists.
+        Return the gitlab_user for a src_user if one exists.
         """
-        return self.users.get(github_user)
+        return self.users.get(src_user)

--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -101,6 +101,7 @@ class GitHubClient:
             gh = gh_aiohttp.GitHubAPI(session, self.requester, oauth_token=gh_token)
 
             # get the contents of the repository hubcast.yml file
+            # the forge is github so the config will be under .github
             url = f"/repos/{self.repo_owner}/{self.repo_name}/contents/.github/hubcast.yml"
             # get raw contents rather than base64 encoded text
             config_str = await gh.getitem(url, accept="application/vnd.github.raw")

--- a/src/hubcast/clients/gitlab/__init__.py
+++ b/src/hubcast/clients/gitlab/__init__.py
@@ -1,3 +1,13 @@
-from .client import GitLabClient, GitLabClientFactory
+from .client import (
+    GitLabClient,
+    GitLabClientFactory,
+    GitLabSrcClient,
+    GitLabSrcClientFactory,
+)
 
-__all__ = ["GitLabClient", "GitLabClientFactory"]
+__all__ = [
+    "GitLabClient",
+    "GitLabClientFactory",
+    "GitLabSrcClient",
+    "GitLabSrcClientFactory",
+]

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -54,7 +54,8 @@ class GitLabClientFactory:
 
 class GitLabSrcClientFactory:
     def __init__(self, instance_url, access_token, requester):
-        self.auth = GitLabAuthenticator(instance_url, access_token)
+        # for source clients we only support single user authentication
+        self.auth = GitLabSingleUserAuthenticator(access_token)
         self.instance_url = instance_url
         self.requester = requester
 
@@ -207,7 +208,7 @@ class GitLabSrcClient:
         self.repo_id = repo_id
 
     async def get_repo_config(self):
-        gl_token = await self.auth.authenticate_installation(self.requester)
+        gl_token = await self.auth.authenticate_user(self.requester)
 
         async with aiohttp.ClientSession() as session:
             gl = gidgetlab.aiohttp.GitLabAPI(
@@ -237,7 +238,7 @@ class GitLabSrcClient:
         # status can be directly mapped from gitlab->gitlab
         payload = {"name": check_name, "target_url": details_url, "state": status}
 
-        gl_token = await self.auth.authenticate_installation(self.requester)
+        gl_token = await self.auth.authenticate_user(self.requester)
 
         async with aiohttp.ClientSession() as session:
             gl = gidgetlab.aiohttp.GitLabAPI(

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -1,10 +1,18 @@
+import logging
 import urllib.parse
 from typing import Dict
 
 import aiohttp
 import gidgetlab.aiohttp
+import yaml
 
 from .auth import GitLabAuthenticator, GitLabSingleUserAuthenticator
+
+log = logging.getLogger(__name__)
+
+
+class InvalidConfigYAMLError(Exception):
+    pass
 
 
 class GitLabClientFactory:
@@ -32,6 +40,9 @@ class GitLabClientFactory:
 
     def create_client(self, user: str):
         """creates a GitLabClient for a specific user"""
+        # for the destination client, the user is grabbed from the account map
+        # and will ultimately authenticate with the destination instance
+        # and run CI jobs as that user
         return GitLabClient(
             self.auth,
             self.instance_url,
@@ -39,6 +50,92 @@ class GitLabClientFactory:
             self.webhook_secret,
             user,
         )
+
+
+class GitLabSrcClientFactory:
+    def __init__(self, instance_url, access_token, requester):
+        self.auth = GitLabAuthenticator(instance_url, access_token)
+        self.instance_url = instance_url
+        self.requester = requester
+
+    def create_client(self, repo_id):
+        return GitLabSrcClient(self.auth, self.instance_url, self.requester, repo_id)
+
+
+class GitLabSrcClient:
+    def __init__(self, auth, instance_url, requester, repo_id):
+        self.auth = auth
+        self.instance_url = instance_url
+        self.requester = requester
+        self.repo_id = repo_id
+
+    async def get_repo_config(self):
+        gl_token = await self.auth.authenticate_installation(self.requester)
+
+        async with aiohttp.ClientSession() as session:
+            gl = gidgetlab.aiohttp.GitLabAPI(
+                session, self.requester, access_token=gl_token, url=self.instance_url
+            )
+
+            filepath = urllib.parse.quote_plus(".github/hubcast.yml")
+            url = f"/projects/{self.repo_id}/repository/files/{filepath}/raw"
+            config_str = await gl.getitem(url)
+
+            try:
+                config = yaml.safe_load(config_str)
+            except yaml.YAMLError as exc:
+                log.error(
+                    f"[{self.instance_url} -- {self.repo_id}]: Unable to parse config: {exc}"
+                )
+                raise InvalidConfigYAMLError()
+
+            return config
+
+    async def set_check_status(
+        self, ref: str, check_name: str, status: str, details_url: str
+    ):
+        """note: this is known as 'pipeline status' in Gitlab, but we keep the same signature from the Github implementation for consistency"""
+        # status can be directly mapped from gitlab->gitlab
+        payload = {"name": check_name, "target_url": details_url, "state": status}
+
+        gl_token = await self.auth.authenticate_installation(self.requester)
+
+        async with aiohttp.ClientSession() as session:
+            gl = gidgetlab.aiohttp.GitLabAPI(
+                session, self.requester, access_token=gl_token, url=self.instance_url
+            )
+
+            # get a list of the current checks on a commit
+            url = f"/projects/{self.repo_id}/repository/commits/{ref}/statuses"
+            data = await gl.getitem(url)
+
+            # search for existing check
+            existing_check = None
+            for check in data:
+                if check["name"] == check_name:
+                    existing_check = check
+                    break
+
+            if existing_check:
+                # The ID of the pipeline to set status. Use in case of several pipeline on same SHA.
+                payload["pipeline_id"] = existing_check["pipeline_id"]
+            # else the status, failed, or canceled status will get forwarded
+
+            url = f"/projects/{self.repo_id}/statuses/{ref}"
+            try:
+                await gl.post(url, data=payload)
+            except Exception as exc:
+                if "Cannot transition status" in str(exc):
+                    # see https://forum.gitlab.com/t/cannot-transition-status-via-run-from-running-reason-s-status-cannot-transition-via-run/42588/7
+                    # the program enters this state if the pipeline/commit status is updated to a status ≤ the current status
+                    # for instance, setting it to pending when it's already running
+                    # this also means that we can't update other parts of the payload (eg target_url) without increasing the "value" of the status
+                    # i've seen this exception when gl.post() call to update the status to `running` is sent before the `pending` state
+                    # we ignore the exception in this case as the user is still receiving up-to-date information about the status of their pipeline
+                    # the events arrive in a jumbled order sometimes pending -> running -> created
+                    pass
+                else:
+                    print(exc)
 
 
 class GitLabClient:

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -214,7 +214,9 @@ class GitLabSrcClient:
                 session, self.requester, access_token=gl_token, url=self.instance_url
             )
 
-            filepath = urllib.parse.quote_plus(".github/hubcast.yml")
+            # get the contents of the repository hubcast.yml file
+            # the forge is github so the config will be under .github
+            filepath = urllib.parse.quote_plus(".gitlab/hubcast.yml")
             url = f"/projects/{self.repo_id}/repository/files/{filepath}/raw"
             config_str = await gl.getitem(url)
 

--- a/src/hubcast/config.py
+++ b/src/hubcast/config.py
@@ -1,5 +1,9 @@
+import logging
 import os
+import sys
 from typing import Optional
+
+log = logging.getLogger(__name__)
 
 
 class ConfigError(Exception):
@@ -13,30 +17,46 @@ class Config:
         self.account_map_type = env_get("HC_ACCOUNT_MAP_TYPE")
         self.account_map_path = env_get("HC_ACCOUNT_MAP_PATH")
         self.logging_config_path = env_get("HC_LOGGING_CONFIG_PATH")
+        self.src_service = env_get("HC_SRC_SERVICE", "").lower()
 
-        self.gh = GitHubConfig()
-        self.gl = GitLabConfig()
+        if self.src_service == "github":
+            self.gh_src = GitHubSrcConfig()
+        elif self.src_service == "gitlab":
+            self.gl_src = GitLabSrcConfig()
+        else:
+            log.error('the source service can only be one of "gitlab" or "github"')
+            sys.exit(1)
+
+        self.gl_dest = GitLabDestConfig()
 
 
-class GitHubConfig:
+class GitHubSrcConfig:
     def __init__(self):
-        self.app_id = env_get("HC_GH_APP_IDENTIFIER")
-        self.privkey = env_get("HC_GH_PRIVATE_KEY")
-        self.requester = env_get("HC_GH_REQUESTER")
-        self.webhook_secret = env_get("HC_GH_SECRET")
+        self.app_id = env_get("HC_GH_SRC_APP_IDENTIFIER")
+        self.privkey = env_get("HC_GH_SRC_PRIVATE_KEY")
+        self.requester = env_get("HC_GH_SRC_REQUESTER")
+        self.webhook_secret = env_get("HC_GH_SRC_WEBHOOK_SECRET")
         self.bot_user = env_get("HC_GH_BOT_USER")
 
 
-class GitLabConfig:
+class GitLabSrcConfig:
     def __init__(self):
-        self.instance_url = env_get("HC_GL_URL")
+        self.instance_url = env_get("HC_GL_SRC_URL")
+        self.access_token = env_get("HC_GL_SRC_ACCESS_TOKEN")
+        self.requester = env_get("HC_GL_SRC_REQUESTER")
+        self.webhook_secret = env_get("HC_GL_SRC_WEBHOOK_SECRET")
+
+
+class GitLabDestConfig:
+    def __init__(self):
+        self.instance_url = env_get("HC_GL_DEST_URL")
         # requester identifies the app making requests, it doesn't
         # perform any auth function but is included in user-agent
         self.requester = env_get("HC_GL_REQUESTER")
-        self.token = env_get("HC_GL_TOKEN")
-        self.token_type = env_get("HC_GL_TOKEN_TYPE", default="impersonation")
-        self.webhook_secret = env_get("HC_GL_SECRET")
-        self.callback_url = env_get("HC_GL_CALLBACK_URL")
+        self.token = env_get("HC_GL_DEST_TOKEN")
+        self.token_type = env_get("HC_GL_DEST_TOKEN_TYPE", default="impersonation")
+        self.webhook_secret = env_get("HC_GL_DEST_SECRET")
+        self.callback_url = env_get("HC_GL_DEST_CALLBACK_URL")
 
 
 def env_get(key: str, default: Optional[str] = None) -> str:

--- a/src/hubcast/config.py
+++ b/src/hubcast/config.py
@@ -17,14 +17,14 @@ class Config:
         self.account_map_type = env_get("HC_ACCOUNT_MAP_TYPE")
         self.account_map_path = env_get("HC_ACCOUNT_MAP_PATH")
         self.logging_config_path = env_get("HC_LOGGING_CONFIG_PATH")
-        self.src_service = env_get("HC_SRC_SERVICE", "").lower()
+        self.src_forge = env_get("HC_SRC_FORGE", "").lower()
 
-        if self.src_service == "github":
+        if self.src_forge == "github":
             self.gh_src = GitHubSrcConfig()
-        elif self.src_service == "gitlab":
+        elif self.src_forge == "gitlab":
             self.gl_src = GitLabSrcConfig()
         else:
-            log.error('the source service can only be one of "gitlab" or "github"')
+            log.error('the source forge can only be one of "gitlab" or "github"')
             sys.exit(1)
 
         self.gl_dest = GitLabDestConfig()

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -6,7 +6,7 @@ from gidgethub import routing, sansio
 from repligit.asyncio import fetch_pack, ls_remote, send_pack
 
 from hubcast.web import comments
-from hubcast.web.github.utils import get_repo_config
+from hubcast.web.utils import get_repo_config
 
 log = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ router = GitHubRouter()
 # Push Events
 # -----------------------------------
 @router.register("push", deleted=False)
-async def sync_branch(event, gh, gl, gl_user, *arg, **kwargs):
+async def sync_branch(event, gh, gl, gl_user, *args, **kwargs):
     """Sync the git branch referenced to GitLab."""
     src_repo_url = event.data["repository"]["clone_url"]
     src_fullname = event.data["repository"]["full_name"]
@@ -59,9 +59,10 @@ async def sync_branch(event, gh, gl, gl_user, *arg, **kwargs):
 
     # setup callback webhook on GitLab
     webhook_data = {
-        "gh_owner": src_owner,
-        "gh_repo": src_repo_name,
-        "gh_check": repo_config.check_name,
+        "src_owner": src_owner,
+        "src_repo_name": src_repo_name,
+        "src_check_name": repo_config.check_name,
+        "src_service": "github",
     }
     await gl.set_webhook(dest_fullname, webhook_data)
 
@@ -105,7 +106,7 @@ async def sync_branch(event, gh, gl, gl_user, *arg, **kwargs):
 
 
 @router.register("push", deleted=True)
-async def remove_branch(event, gh, gl, gl_user, *arg, **kwargs):
+async def remove_branch(event, gh, gl, gl_user, *args, **kwargs):
     src_fullname = event.data["repository"]["full_name"]
     target_ref = event.data["ref"]
 
@@ -206,14 +207,14 @@ async def sync_pr(pull_request, gh, gl, gl_user):
 @router.register("pull_request", action="opened")
 @router.register("pull_request", action="reopened")
 @router.register("pull_request", action="synchronize")
-async def sync_pr_event(event, gh, gl, gl_user, *arg, **kwargs):
+async def sync_pr_event(event, gh, gl, gl_user, *args, **kwargs):
     """Sync the git fork/branch referenced in a PR to GitLab."""
     pull_request = event.data["pull_request"]
     await sync_pr(pull_request, gh, gl, gl_user)
 
 
 @router.register("pull_request", action="closed")
-async def remove_pr(event, gh, gl, gl_user, *arg, **kwargs):
+async def remove_pr(event, gh, gl, gl_user, *args, **kwargs):
     pull_request = event.data["pull_request"]
     src_fullname = pull_request["head"]["repo"]["full_name"]
 

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -158,7 +158,7 @@ async def sync_pr(pull_request, gh, gl, gl_user):
     else:
         target_ref = f"refs/heads/{pull_request['head']['ref']}"
 
-    # get the repository configuration from .github/hubcast.yml
+    # get the repository configuration
     repo_config = await get_repo_config(gh, src_fullname)
 
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
@@ -230,7 +230,7 @@ async def remove_pr(event, gh, gl, gl_user, *args, **kwargs):
     pull_request_id = pull_request["number"]
     target_ref = f"refs/heads/pr-{pull_request_id}"
 
-    # get the repository configuration from .github/hubcast.yml
+    # get the repository configuration
     repo_config = await get_repo_config(gh, src_fullname)
 
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -62,7 +62,7 @@ async def sync_branch(event, gh, gl, gl_user, *args, **kwargs):
         "src_owner": src_owner,
         "src_repo_name": src_repo_name,
         "src_check_name": repo_config.check_name,
-        "src_service": "github",
+        "src_forge": "github",
     }
     await gl.set_webhook(dest_fullname, webhook_data)
 

--- a/src/hubcast/web/gitlab/__init__.py
+++ b/src/hubcast/web/gitlab/__init__.py
@@ -1,3 +1,3 @@
-from .handler import GitLabHandler
+from .handler import GitLabHandler, GitLabSrcHandler
 
-__all__ = ["GitLabHandler"]
+__all__ = ["GitLabHandler", "GitLabSrcHandler"]

--- a/src/hubcast/web/gitlab/handler.py
+++ b/src/hubcast/web/gitlab/handler.py
@@ -58,7 +58,7 @@ class GitLabHandler:
             return web.Response(status=200)
 
         except Exception:
-            traceback.print_exc(file=sys.stderr)
+            log.exception("Failed to handle GitLab webhook")
             return web.Response(status=500)
 
 

--- a/src/hubcast/web/gitlab/handler.py
+++ b/src/hubcast/web/gitlab/handler.py
@@ -31,27 +31,27 @@ class GitLabHandler:
             )
             log.info("GitLab webhook received", extra={"event_type": event.event})
 
-            src_service = request.rel_url.query["src_service"]
+            src_forge = request.rel_url.query["src_forge"]
             src_check_name = request.rel_url.query["src_check_name"]
 
             # get corresponding GitHub repo owner and name from event request variables
-            # create_client takes different args depending on the service
-            # required webhook data in the query args also depends on the service
-            if src_service == "github":
+            # create_client takes different args depending on the forge
+            # required webhook data in the query args also depends on the forge
+            if src_forge == "github":
                 src_repo_name = request.rel_url.query["src_repo_name"]
                 src_repo_owner = request.rel_url.query["src_owner"]
                 src_client = self.src_client_factory.create_client(
                     src_repo_owner, src_repo_name
                 )
-            elif src_service == "gitlab":
+            elif src_forge == "gitlab":
                 src_repo_id = request.rel_url.query["src_repo_id"]
                 src_client = self.src_client_factory.create_client(src_repo_id)
             else:
-                log.warning(f"invalid src service {src_service}")
+                log.warning(f"invalid src forge {src_forge}")
 
             await spawn(
                 request,
-                router.dispatch(event, src_service, src_client, src_check_name),
+                router.dispatch(event, src_forge, src_client, src_check_name),
             )
 
             # return a "Success"

--- a/src/hubcast/web/gitlab/handler.py
+++ b/src/hubcast/web/gitlab/handler.py
@@ -6,6 +6,7 @@ from gidgetlab import sansio
 from gidgetlab.exceptions import ValidationFailure
 
 from hubcast.clients.github import GitHubClientFactory
+from hubcast.clients.gitlab import GitLabSrcClientFactory
 
 from .routes import router
 
@@ -13,9 +14,13 @@ log = logging.getLogger(__name__)
 
 
 class GitLabHandler:
-    def __init__(self, webhook_secret: str, github_client_factory: GitHubClientFactory):
+    def __init__(
+        self,
+        webhook_secret: str,
+        src_client_factory: GitHubClientFactory | GitLabSrcClientFactory,
+    ):
         self.webhook_secret = webhook_secret
-        self.github_client_factory = github_client_factory
+        self.src_client_factory = src_client_factory
 
     async def handle(self, request):
         try:
@@ -26,20 +31,79 @@ class GitLabHandler:
             )
             log.info("GitLab webhook received", extra={"event_type": event.event})
 
-            # get coorisponding GitHub repo owner and name from event
-            # request variables
-            gh_repo_owner = request.rel_url.query["gh_owner"]
-            gh_repo = request.rel_url.query["gh_repo"]
+            src_service = request.rel_url.query["src_service"]
+            src_check_name = request.rel_url.query["src_check_name"]
 
-            github_client = self.github_client_factory.create_client(
-                gh_repo_owner, gh_repo
-            )
-
-            gh_check_name = request.rel_url.query["gh_check"]
+            # get corresponding GitHub repo owner and name from event request variables
+            # create_client takes different args depending on the service
+            # required webhook data in the query args also depends on the service
+            if src_service == "github":
+                src_repo_name = request.rel_url.query["src_repo_name"]
+                src_repo_owner = request.rel_url.query["src_owner"]
+                src_client = self.src_client_factory.create_client(
+                    src_repo_owner, src_repo_name
+                )
+            elif src_service == "gitlab":
+                src_repo_id = request.rel_url.query["src_repo_id"]
+                src_client = self.src_client_factory.create_client(src_repo_id)
+            else:
+                log.warning(f"invalid src service {src_service}")
 
             await spawn(
                 request,
-                router.dispatch(event, github_client, gh_check_name),
+                router.dispatch(event, src_service, src_client, src_check_name),
+            )
+
+            # return a "Success"
+            return web.Response(status=200)
+
+        except Exception:
+            traceback.print_exc(file=sys.stderr)
+            return web.Response(status=500)
+
+
+class GitLabSrcHandler:
+    def __init__(
+        self, webhook_secret: str, account_map, src_client_factory, dest_client_factory
+    ):
+        self.webhook_secret = webhook_secret
+        self.account_map = account_map
+        self.src = src_client_factory
+        self.dest = dest_client_factory
+
+    async def handle(self, request):
+        try:
+            # read the GitLab webhook payload
+            body = await request.read()
+            event = sansio.Event.from_http(
+                request.headers, body, secret=self.webhook_secret
+            )
+
+            log.info(f"GL delivery ID: {event.event}")
+            try:
+                # the Push Hook provides user_username
+                # the Merge Request Hook provides user["username"]
+                # they are equivalent -- can verify with the user ID or avatar URL
+                src_user = event.data.get("user", {}).get("username") or event.data.get(
+                    "user_username"
+                )
+                dest_user = self.account_map(src_user)
+            except Exception as exc:
+                log.error(exc)
+                return web.Response(status=200)
+
+            if dest_user is None:
+                log.info(f"Unauthorized user: {src_user}")
+                return web.Response(status=200)
+
+            src_repo_id = event.data["project"]["id"]
+
+            gl_src = self.src.create_client(src_repo_id)
+            gl_dest = self.dest.create_client(dest_user)
+
+            await spawn(
+                request,
+                router.dispatch(event, gl_src, gl_dest, dest_user),
             )
 
             # return a "Success"

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -2,6 +2,9 @@ import logging
 from typing import Any
 
 from gidgetlab import routing, sansio
+from repligit.asyncio import fetch_pack, ls_remote, send_pack
+
+from hubcast.web.utils import get_repo_config
 
 log = logging.getLogger(__name__)
 
@@ -43,6 +46,199 @@ class GitLabRouter(routing.Router):
 
 
 router = GitLabRouter()
+log = logging.getLogger(__name__)
+
+
+# -----------------------------------
+# Push Events
+# -----------------------------------
+@router.register("Push Hook")
+async def sync_branch(event, gl_src, gl_dest, dest_user, *args, **kwargs):
+    """Sync a git branch to the destination."""
+
+    # manually handle deleted branches unlike github, which provides the `deleted` attribute
+    if event.data["after"] == "0" * 40:
+        await remove_branch(event, gl_src, gl_dest, dest_user, *args, **kwargs)
+        return
+
+    src_repo_url = event.data["repository"]["git_http_url"]
+    src_fullname = event.data["project"]["path_with_namespace"]
+    repo_id = event.data["project_id"]
+    # after represents the new HEAD of the ref
+    want_sha = event.data["after"]
+    target_ref = event.data["ref"]
+
+    # skip branches from push events that are also merge requests
+    src_refs = await ls_remote(src_repo_url)
+    pull_refs = [
+        src_refs[ref] for ref in src_refs if ref.startswith("refs/merge-requests/")
+    ]
+    if want_sha in pull_refs:
+        return
+
+    repo_config = await get_repo_config(gl_src, src_fullname, refresh=True)
+
+    dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
+    dest_remote_url = f"{gl_dest.instance_url}/{dest_fullname}.git"
+
+    webhook_data = {
+        "src_repo_id": repo_id,
+        "src_check_name": repo_config.check_name,
+        "src_service": "gitlab",
+    }
+    await gl_dest.set_webhook(dest_fullname, webhook_data)
+
+    # sync commits from source -> destination
+    dest_refs = await ls_remote(dest_remote_url)
+    have_shas = dest_refs.values()
+    from_sha = dest_refs.get(target_ref) or ("0" * 40)
+
+    if want_sha in have_shas:
+        log.info(f"[{src_fullname}]: {target_ref} already up-to-date")
+        return
+
+    packfile = await fetch_pack(src_repo_url, want_sha, have_shas)
+
+    dest_token = await gl_dest.auth.authenticate_installation(dest_user)
+
+    log.info(f"[{src_fullname}]: mirroring {from_sha} -> {want_sha}")
+    await send_pack(
+        dest_remote_url,
+        target_ref,
+        from_sha,
+        want_sha,
+        packfile,
+        username=dest_user,
+        password=dest_token,
+    )
+
+
+async def remove_branch(event, gl_src, gl_dest, dest_user, *args, **kwargs):
+    """Delete a git branch from a destination."""
+
+    src_fullname = event.data["project"]["path_with_namespace"]
+    target_ref = event.data["ref"]
+
+    repo_config = await get_repo_config(gl_src, src_fullname, refresh=True)
+
+    dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
+    dest_remote_url = f"{gl_dest.instance_url}/{dest_fullname}.git"
+
+    dest_refs = await ls_remote(dest_remote_url)
+    head_sha = dest_refs.get(target_ref)
+    null_sha = "0" * 40
+
+    dest_token = await gl_dest.auth.authenticate_installation(dest_user)
+
+    log.info(f"[{src_fullname}]: deleting {target_ref}")
+    await send_pack(
+        dest_remote_url,
+        target_ref,
+        head_sha,
+        null_sha,
+        b"",
+        username=dest_user,
+        password=dest_token,
+    )
+
+
+# -----------------------------------
+# Merge Request Events
+# -----------------------------------
+@router.register("Merge Request Hook", action="open")
+@router.register("Merge Request Hook", action="reopen")
+@router.register("Merge Request Hook", action="update")
+async def sync_mr(event, gl_src, gl_dest, dest_user, *args, **kwawrgs):
+    """Sync the git fork/branch referenced in an MR to the destination."""
+
+    merge_request_id = event.data["object_attributes"]["iid"]
+
+    src_repo_url = event.data["object_attributes"]["source"]["git_http_url"]
+    src_fullname = event.data["object_attributes"]["source"]["path_with_namespace"]
+    want_sha = event.data["object_attributes"]["last_commit"]["id"]
+
+    # merge requests coming from forks are pushed as branches in the form of
+    # mr-<mr-number> instead of as their branch name as conflicts could occur
+    # between multiple repositories
+    is_from_fork = (
+        event.data["object_attributes"]["source"]["id"]
+        != event.data["object_attributes"]["target"]["id"]
+    )
+    if is_from_fork:
+        target_ref = f"refs/heads/mr-{merge_request_id}"
+    else:
+        target_ref = f"refs/heads/{event.data['object_attributes']['source_branch']}"
+
+    repo_config = await get_repo_config(gl_src, src_fullname, refresh=True)
+
+    dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
+    dest_remote_url = f"{gl_dest.instance_url}/{dest_fullname}.git"
+
+    # sync commits from source -> destination
+    dest_refs = await ls_remote(dest_remote_url)
+    have_shas = dest_refs.values()
+    from_sha = dest_refs.get(target_ref) or ("0" * 40)
+
+    if want_sha in have_shas:
+        log.info(f"[{src_fullname}]: {target_ref} already up-to-date")
+        return
+
+    packfile = await fetch_pack(src_repo_url, want_sha, have_shas)
+
+    dest_token = await gl_dest.auth.authenticate_installation(dest_user)
+
+    log.info(f"[{src_fullname}]: mirroring {from_sha} -> {want_sha}")
+    await send_pack(
+        dest_remote_url,
+        target_ref,
+        from_sha,
+        want_sha,
+        packfile,
+        username=dest_user,
+        password=dest_token,
+    )
+
+
+@router.register("Merge Request Hook", action="close")
+async def remove_mr(event, gl_src, gl_dest, dest_user, *args, **kwawrgs):
+    src_fullname = event.data["object_attributes"]["source"]["path_with_namespace"]
+
+    # if the merge request comes from a fork we should clean up
+    # the branch upon closing or merging the MR. However, if the
+    # merge request comes from an internal branch we should wait
+    # to clean up the branch when the branch is deleted from the
+    # internal repository
+    is_from_fork = (
+        event.data["object_attributes"]["source"]["id"]
+        != event.data["object_attributes"]["target"]["id"]
+    )
+    if not is_from_fork:
+        return
+
+    merge_request_id = event.data["object_attributes"]["iid"]
+    target_ref = f"refs/heads/mr-{merge_request_id}"
+
+    repo_config = await get_repo_config(gl_src, src_fullname, refresh=True)
+
+    dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
+    dest_remote_url = f"{gl_dest.instance_url}/{dest_fullname}.git"
+
+    dest_refs = await ls_remote(dest_remote_url)
+    head_sha = dest_refs.get(target_ref)
+    null_sha = "0" * 40
+
+    dest_token = await gl_dest.auth.authenticate_installation(dest_user)
+
+    log.info(f"[{src_fullname}]: deleting {target_ref}")
+    await send_pack(
+        dest_remote_url,
+        target_ref,
+        head_sha,
+        null_sha,
+        b"",
+        username=dest_user,
+        password=dest_token,
+    )
 
 
 @router.register("Pipeline Hook", status="pending")
@@ -50,7 +246,9 @@ router = GitLabRouter()
 @router.register("Pipeline Hook", status="success")
 @router.register("Pipeline Hook", status="failed")
 @router.register("Pipeline Hook", status="canceled")
-async def status_relay(event, gh, gh_check_name, *arg, **kwargs):
+async def status_relay(
+    event, src_service: str, src_client, src_check_name, *arg, **kwargs
+):
     """Relay status of a GitLab pipeline back to GitHub."""
     # get ref from event
     ref = event.data["object_attributes"]["sha"]
@@ -59,19 +257,24 @@ async def status_relay(event, gh, gh_check_name, *arg, **kwargs):
     ci_status = event.data["object_attributes"]["status"]
     pipeline_url = event.data["object_attributes"]["url"]
 
-    # https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks#about-check-suites
-    # https://docs.gitlab.com/api/pipelines/#list-project-pipelines -> status description
-
-    # translate between GitLab and GitHub statuses
-    if ci_status == "pending":
-        status = "queued"
-    elif ci_status == "running":
-        status = "in_progress"
-    elif ci_status == "failed":
-        status = "failure"
-    elif ci_status == "canceled":
-        status = "cancelled"
-    else:
+    if src_service == "gitlab":
+        # doesn't need to be mapped
         status = ci_status
+    elif src_service == "github":
+        # https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks#about-check-suites
+        # https://docs.gitlab.com/api/pipelines/#list-project-pipelines -> status description
 
-    await gh.set_check_status(ref, gh_check_name, status, pipeline_url)
+        # translate between GitLab and GitHub statuses
+        if ci_status == "pending":
+            status = "queued"
+        elif ci_status == "running":
+            status = "in_progress"
+        elif ci_status == "failed":
+            status = "failure"
+        elif ci_status == "canceled":
+            status = "cancelled"
+        else:
+            status = ci_status
+
+    # both gitlab and github src clients have the same signature
+    await src_client.set_check_status(ref, src_check_name, status, pipeline_url)

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -84,7 +84,7 @@ async def sync_branch(event, gl_src, gl_dest, dest_user, *args, **kwargs):
     webhook_data = {
         "src_repo_id": repo_id,
         "src_check_name": repo_config.check_name,
-        "src_service": "gitlab",
+        "src_forge": "gitlab",
     }
     await gl_dest.set_webhook(dest_fullname, webhook_data)
 
@@ -247,7 +247,7 @@ async def remove_mr(event, gl_src, gl_dest, dest_user, *args, **kwawrgs):
 @router.register("Pipeline Hook", status="failed")
 @router.register("Pipeline Hook", status="canceled")
 async def status_relay(
-    event, src_service: str, src_client, src_check_name, *arg, **kwargs
+    event, src_forge: str, src_client, src_check_name, *arg, **kwargs
 ):
     """Relay status of a GitLab pipeline back to GitHub."""
     # get ref from event
@@ -257,10 +257,10 @@ async def status_relay(
     ci_status = event.data["object_attributes"]["status"]
     pipeline_url = event.data["object_attributes"]["url"]
 
-    if src_service == "gitlab":
+    if src_forge == "gitlab":
         # doesn't need to be mapped
         status = ci_status
-    elif src_service == "github":
+    elif src_forge == "github":
         # https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks#about-check-suites
         # https://docs.gitlab.com/api/pipelines/#list-project-pipelines -> status description
 

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -101,7 +101,7 @@ async def sync_branch(event, gl_src, gl_dest, dest_user, *args, **kwargs):
     dest_refs = await ls_remote(
         dest_remote_url, username=dest_user, password=dest_token
     )
-    have_shas = dest_refs.values()
+    have_shas = set(dest_refs.values())
     from_sha = dest_refs.get(target_ref) or ("0" * 40)
 
     if want_sha in have_shas:
@@ -214,7 +214,7 @@ async def sync_mr(event, gl_src, gl_dest, dest_user, *args, **kwawrgs):
     dest_refs = await ls_remote(
         dest_remote_url, username=dest_user, password=dest_token
     )
-    have_shas = dest_refs.values()
+    have_shas = set(dest_refs.values())
     from_sha = dest_refs.get(target_ref) or ("0" * 40)
 
     if want_sha in have_shas:

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -73,7 +73,7 @@ async def sync_branch(event, gl_src, gl_dest, dest_user, *args, **kwargs):
     if private_src_repo:
         src_creds = {
             "username": gl_src.requester,
-            "password": await gl_src.auth.authenticate_installation(gl_src.requester),
+            "password": await gl_src.auth.authenticate_user(gl_src.requester),
         }
 
     # skip branches from push events that are also merge requests
@@ -95,7 +95,7 @@ async def sync_branch(event, gl_src, gl_dest, dest_user, *args, **kwargs):
         "src_forge": "gitlab",
     }
     await gl_dest.set_webhook(dest_fullname, webhook_data)
-    dest_token = await gl_dest.auth.authenticate_installation(dest_user)
+    dest_token = await gl_dest.auth.authenticate_user(dest_user)
 
     # sync commits from source -> destination
     dest_refs = await ls_remote(
@@ -132,7 +132,7 @@ async def remove_branch(event, gl_src, gl_dest, dest_user, *args, **kwargs):
 
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
     dest_remote_url = f"{gl_dest.instance_url}/{dest_fullname}.git"
-    dest_token = await gl_dest.auth.authenticate_installation(dest_user)
+    dest_token = await gl_dest.auth.authenticate_user(dest_user)
 
     dest_refs = await ls_remote(
         dest_remote_url, username=dest_user, password=dest_token
@@ -175,7 +175,7 @@ async def sync_mr(event, gl_src, gl_dest, dest_user, *args, **kwawrgs):
     if private_src_repo:
         src_creds = {
             "username": gl_src.requester,
-            "password": await gl_src.auth.authenticate_installation(gl_src.requester),
+            "password": await gl_src.auth.authenticate_user(gl_src.requester),
         }
 
     # merge requests coming from forks are pushed as branches in the form of
@@ -208,7 +208,7 @@ async def sync_mr(event, gl_src, gl_dest, dest_user, *args, **kwawrgs):
 
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
     dest_remote_url = f"{gl_dest.instance_url}/{dest_fullname}.git"
-    dest_token = await gl_dest.auth.authenticate_installation(dest_user)
+    dest_token = await gl_dest.auth.authenticate_user(dest_user)
 
     # sync commits from source -> destination
     dest_refs = await ls_remote(
@@ -258,7 +258,7 @@ async def remove_mr(event, gl_src, gl_dest, dest_user, *args, **kwawrgs):
 
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
     dest_remote_url = f"{gl_dest.instance_url}/{dest_fullname}.git"
-    dest_token = await gl_dest.auth.authenticate_installation(dest_user)
+    dest_token = await gl_dest.auth.authenticate_user(dest_user)
 
     dest_refs = await ls_remote(
         dest_remote_url, username=dest_user, password=dest_token

--- a/src/hubcast/web/utils.py
+++ b/src/hubcast/web/utils.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 from hubcast.clients.github import GitHubClient
 from hubcast.clients.github.client import InvalidConfigYAMLError
+from hubcast.clients.gitlab import GitLabSrcClient
 from hubcast.repos.config import RepoConfig
 
 config_cache = dict()
@@ -17,12 +18,15 @@ def create_config(fullname: str, data: Dict) -> RepoConfig:
     )
 
 
-async def get_repo_config(gh: GitHubClient, fullname: str, refresh: bool = False):
+async def get_repo_config(
+    src_client: GitHubClient | GitLabSrcClient, fullname: str, refresh: bool = False
+):
+    # the client must implement the get_repo_config method in the standard format
     if fullname in config_cache and not refresh:
         config = config_cache[fullname]
     else:
         try:
-            data = await gh.get_repo_config()
+            data = await src_client.get_repo_config()
         except InvalidConfigYAMLError:
             log.exception("Repo config parse failed")
 


### PR DESCRIPTION
This PR enables syncing commits (and pipeline statuses) between repositories on two Gitlab instances.

Modifications were made to several parts of the codebase:
- global config options are more verbose to accommodate Gitlab and Github both being options for the source
- there are now two Gitlab client classes (for dest and src). the logic is different and consolidating them would have a negative effect on readability, imo (open to disagreement though)
- there are also two Gitlab handler classes for similar reasons
- many new route handlers in `src/hubcast/web/gitlab/routes.py`

Feedback would be helpful on software arch decisions and potential consolidation of functionality.

closes #115

outstanding issues (see comments below):

- [ ] can't post pipeline status to forked repos
- [ ] bot user for source gitlab instance?
- [ ] naming of handler and client classes for src/dest

TODOs after this PR:

- [ ] bot/commenting functionality
- [ ] draft PR sync conditional