### PR TITLE
Add permissions blocks to GitHub Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: ci
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-permissions:
-  contents: read
 name: ci
 on:
   push:
@@ -8,6 +6,9 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
 
 concurrency:
   group: ci-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Linting & Style Checks
 on:
   # This Workflow can be triggered manually

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,11 +1,9 @@
-permissions:
-  contents: read
 name: Linting & Style Checks
 on:
-  # This Workflow can be triggered manually
-  workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Unit Tests
 on:
   # This Workflow can be triggered manually

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,10 +1,9 @@
-permissions:
-  contents: read
 name: Unit Tests
 on:
-  # This Workflow can be triggered manually
-  workflow_dispatch:
   workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   ubuntu:


### PR DESCRIPTION
Potential fix for [https://github.com/LLNL/hubcast/security/code-scanning/7](https://github.com/LLNL/hubcast/security/code-scanning/7)

To fix the error, add a top-level `permissions` block near the top of the workflow file with the most restrictive reasonable setting. Since some jobs (like `changes`) set permissions explicitly, the global setting will apply only to jobs that do not specify permissions themselves, such as `style` and `all`. Unless the workflow requires more, the minimal effective permission is usually `contents: read`, which allows actions to read the repository content but not push or modify anything. This block should be inserted at the root level, ideally right under the `name:` and before `on:` (for clarity and convention), or after `on:`.

**Required changes:**
1. In .github/workflows/ci.yml, add:
   ```yaml
   permissions:
     contents: read
   ```
   directly after the `name:` or after the `on:` keys.

**No additional dependencies or external configuration changes are needed.**

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
