### PR TITLE
Add option to control sync of draft PRs

### DIFF
--- a/src/hubcast/repos/config.py
+++ b/src/hubcast/repos/config.py
@@ -8,7 +8,8 @@ class RepoConfig:
         check_type: str = "pipeline",
         create_mr: bool = False,
         delete_closed: bool = True,
-        sync_drafts: bool = True,
+        draft_sync: bool = True,
+        draft_sync_msg: bool = True,
     ):
         self.fullname = fullname
         self.dest_org = dest_org
@@ -17,4 +18,5 @@ class RepoConfig:
         self.check_type = check_type
         self.create_mr = create_mr
         self.delete_closed = delete_closed
-        self.sync_drafts = sync_drafts
+        self.draft_sync = draft_sync
+        self.draft_sync_msg = draft_sync_msg

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -159,9 +159,14 @@ async def sync_pr(pull_request, gh, gl, gl_user):
 
     # get the repository configuration from .github/hubcast.yml
     repo_config = await get_repo_config(gh, src_fullname)
-
-    if not repo_config.sync_drafts and pull_request["draft"]:
-        # TODO comment on the PR that drafts are not being synced once bot functionality PR is merged
+    if not repo_config.draft_sync and pull_request["draft"]:
+        if repo_config.draft_sync_msg:
+            await gh.set_check_status(
+                want_sha,
+                repo_config.check_name,
+                "skipped",
+                message="Hubcast disables sync for draft PRs.",
+            )
         return
 
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -14,7 +14,8 @@ def create_config(fullname: str, data: Dict) -> RepoConfig:
         fullname=fullname,
         dest_org=data["Repo"]["owner"],
         dest_name=data["Repo"]["name"],
-        sync_drafts=data["Repo"].get("sync_drafts", True),
+        draft_sync=data["Repo"].get("draft_sync", True),
+        draft_sync_msg=data["Repo"].get("draft_sync_msg", True),
     )
 
 


### PR DESCRIPTION
Repository maintainers can specify True/False under Repo -> `sync_drafts` in `.github/hubcast.yml`.

Once the Gitlab as a source forge PR is merged we can integrate this option.