### PR TITLE
Remove hardcoding in container tagging action

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -27,4 +27,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: ${{ github.ref == 'refs/heads/main' }}
-          tags: ghcr.io/llnl/hubcast:latest
+          tags: ghcr.io/${{ github.repository }}


### PR DESCRIPTION
Container tags can't have uppercase characters; when the LLNL org was `LLNL`, we couldn't refer to the repo with a variable. It was recently renamed to `llnl`, so it no longer needs to be hardcoded.