### PR TITLE
fix: erroneous method call in sync_branch route

### DIFF
--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -64,7 +64,7 @@ async def sync_branch(event, gh, gl, gl_user, *arg, **kwargs):
         "gh_check": repo_config.check_name,
     }
     await gl.set_webhook(dest_fullname, webhook_data)
-    gl_token = await gl.auth.authenticate_installation(gl_user)
+    gl_token = await gl.auth.authenticate_user(gl_user)
 
     # sync commits from GitHub -> GitLab
     gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)


### PR DESCRIPTION
https://github.com/llnl/hubcast/pull/188 implemented downscoping, which resulted in a name change to the method used to fetch Gitlab tokens. I missed a call in sync_branch, fixed in this PR.