### PR TITLE
remove configurability of "requesters"

### DIFF
--- a/src/hubcast/__main__.py
+++ b/src/hubcast/__main__.py
@@ -70,11 +70,10 @@ def main():
         sys.exit(1)
 
     gh_client_factory = GitHubClientFactory(
-        conf.gh.app_id, conf.gh.privkey, conf.gh.requester, conf.gh.bot_user
+        conf.gh.app_id, conf.gh.privkey, conf.gh.bot_user
     )
     gl_client_factory = GitLabClientFactory(
         conf.gl.instance_url,
-        conf.gl.requester,
         conf.gl.token,
         conf.gl.callback_url,
         conf.gl.webhook_secret,

--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -6,6 +6,11 @@ from gidgethub import aiohttp as gh_aiohttp
 
 from .auth import GitHubAuthenticator
 
+# `requester` does not perform any function other than identifying the client
+# in user-agent headers
+GH_REQUESTER = "hubcast"
+
+
 VALID_GH_REACTIONS = [
     "+1",
     "-1",
@@ -23,9 +28,9 @@ class InvalidConfigYAMLError(Exception):
 
 
 class GitHubClientFactory:
-    def __init__(self, app_id, privkey, requester, bot_user):
-        self.requester = requester
-        self.auth = GitHubAuthenticator(requester, privkey, app_id)
+    def __init__(self, app_id, privkey, bot_user):
+        self.requester = GH_REQUESTER
+        self.auth = GitHubAuthenticator(self.requester, privkey, app_id)
         self.bot_user = bot_user
 
     def create_client(self, repo_owner, repo_name):

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -6,23 +6,26 @@ import gidgetlab.aiohttp
 
 from .auth import GitLabAuthenticator, GitLabSingleUserAuthenticator
 
+# `requester` does not perform any function other than identifying the client
+# in user-agent headers
+GL_REQUESTER = "hubcast"
+
 
 class GitLabClientFactory:
     def __init__(
         self,
         instance_url: str,
-        requester: str,
         token: str,
         callback_url: str,
         webhook_secret: str,
         token_type: str = "impersonation",  # nosec B107
     ):
-        self.requester = requester
+        self.requester = GL_REQUESTER
 
         if token_type == "single":  # nosec B105
             self.auth = GitLabSingleUserAuthenticator(token)
         elif token_type == "impersonation":  # nosec B105
-            self.auth = GitLabAuthenticator(instance_url, requester, token)
+            self.auth = GitLabAuthenticator(instance_url, self.requester, token)
         else:
             raise ValueError(f"Unknown GitLab token type: {token_type}")
 
@@ -34,6 +37,7 @@ class GitLabClientFactory:
         """creates a GitLabClient for a specific user"""
         return GitLabClient(
             self.auth,
+            self.requester,
             self.instance_url,
             self.callback_url,
             self.webhook_secret,
@@ -45,12 +49,14 @@ class GitLabClient:
     def __init__(
         self,
         auth: GitLabAuthenticator,
+        requester: str,
         instance_url: str,
         callback_url: str,
         webhook_secret: str,
         user: str,
     ):
         self.auth = auth
+        self.requester = requester
         self.instance_url = instance_url
         self.callback_url = callback_url
         self.webhook_secret = webhook_secret
@@ -117,7 +123,7 @@ class GitLabClient:
         async with aiohttp.ClientSession() as session:
             gl = gidgetlab.aiohttp.GitLabAPI(
                 session,
-                requester=self.user,
+                requester=self.requester,
                 access_token=gl_token,
                 url=self.instance_url,
             )
@@ -141,7 +147,7 @@ class GitLabClient:
         async with aiohttp.ClientSession() as session:
             gl = gidgetlab.aiohttp.GitLabAPI(
                 session,
-                requester=self.user,
+                requester=self.requester,
                 access_token=gl_token,
                 url=self.instance_url,
             )
@@ -164,7 +170,7 @@ class GitLabClient:
         async with aiohttp.ClientSession() as session:
             gl = gidgetlab.aiohttp.GitLabAPI(
                 session,
-                requester=self.user,
+                requester=self.requester,
                 access_token=gl_token,
                 url=self.instance_url,
             )

--- a/src/hubcast/config.py
+++ b/src/hubcast/config.py
@@ -1,11 +1,6 @@
 import os
 from typing import Optional
 
-# for both github and gitlab `requester`
-# does not perform any function other than
-# identifying the client in user-agent headers
-REQUESTER = "hubcast"
-
 
 class ConfigError(Exception):
     pass
@@ -39,7 +34,6 @@ class GitHubConfig:
     def __init__(self):
         self.app_id = env_get("HC_GH_APP_IDENTIFIER")
         self.privkey = env_get("HC_GH_PRIVATE_KEY")
-        self.requester = REQUESTER
         self.webhook_secret = env_get("HC_GH_SECRET")
         self.bot_user = env_get("HC_GH_BOT_USER")
 
@@ -47,7 +41,6 @@ class GitHubConfig:
 class GitLabConfig:
     def __init__(self):
         self.instance_url = env_get("HC_GL_URL")
-        self.requester = REQUESTER
         self.token = env_get("HC_GL_TOKEN")
         self.token_type = env_get("HC_GL_TOKEN_TYPE", default="impersonation")
         self.webhook_secret = env_get("HC_GL_SECRET")


### PR DESCRIPTION
we currently allow users to set "requester" strings for calls to GitHub and GitLab. They don't seem to get used anywhere in the authentication process for either site, other than getting used as the user-string for each request.

Rather than having to explain this nuance to the user, I propose we use `hubcast` as our user agent and simplify our configuration. The wording is confusing and heavily implies that it is of functional importance.

If someone needs to figure out where a request is coming from, I think "hubcast" as the user agent, combined with signals like the github app id or github token id, is more than enough for any diagnosis.