### PR TITLE
Reorder repo config parsing logic

### DIFF
--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -1,7 +1,6 @@
 from urllib.parse import urlparse
 
 import aiohttp
-import yaml
 from gidgethub import aiohttp as gh_aiohttp
 
 from .auth import GitHubAuthenticator
@@ -16,10 +15,6 @@ VALID_GH_REACTIONS = [
     "rocket",
     "eyes",
 ]
-
-
-class InvalidConfigYAMLError(Exception):
-    pass
 
 
 class GitHubClientFactory:
@@ -132,16 +127,7 @@ class GitHubClient:
             # get the contents of the repository hubcast.yml file
             url = f"/repos/{self.repo_owner}/{self.repo_name}/contents/.github/hubcast.yml"
             # get raw contents rather than base64 encoded text
-            config_str = await gh.getitem(url, accept="application/vnd.github.raw")
-
-            try:
-                config = yaml.safe_load(config_str)
-            except yaml.YAMLError:
-                raise InvalidConfigYAMLError(
-                    f"Failed to parse repo config. repo_owner={self.repo_owner} repo_name={self.repo_name}"
-                )
-
-            return config
+            return await gh.getitem(url, accept="application/vnd.github.raw")
 
     async def get_pr(self, id):
         """Return individual PR data."""

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -1,8 +1,9 @@
 import logging
 from typing import Dict
 
+import yaml
+
 from hubcast.clients.github import GitHubClient
-from hubcast.clients.github.client import InvalidConfigYAMLError
 from hubcast.repos.config import RepoConfig
 
 config_cache = dict()
@@ -23,12 +24,24 @@ async def get_repo_config(gh: GitHubClient, fullname: str, refresh: bool = False
     if fullname in config_cache and not refresh:
         config = config_cache[fullname]
     else:
-        try:
-            data = await gh.get_repo_config()
-        except InvalidConfigYAMLError:
-            log.exception("Repo config parse failed")
+        config_str = await gh.get_repo_config()
 
-        config = create_config(fullname, data)
+        try:
+            config_yaml = yaml.safe_load(config_str)
+        except yaml.YAMLError:
+            log.info(
+                "Repo config is invalid YAML",
+                extra={"repo_owner": gh.repo_owner, "repo_name": gh.repo_name},
+            )
+
+        try:
+            config = create_config(fullname, config_yaml)
+        except KeyError as exc:
+            log.info(
+                f"Repo config is missing required fields: {exc}",
+                extra={"repo_owner": gh.repo_owner, "repo_name": gh.repo_name},
+            )
+
         config_cache[fullname] = config
 
     return config


### PR DESCRIPTION
Some of the logic for parsing the repository configuration is in the GitHub client. This PR moves that logic to the util, which handles invalid YAML in the config and missing keys (new).

This will make it substantially easier to test invalid configurations and keep logic separate from the clients (useful for GL-GL).