### PR TITLE
Fix python-ldap compile error in container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,30 @@
-FROM python:3.12-alpine
-
-ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
+FROM python:3.12-alpine AS build
 WORKDIR /app
+
+RUN apk update && apk add --no-cache \
+      build-base python3-dev \
+      openldap-dev cyrus-sasl-dev \
+      openssl-dev
 
 # copy build deps
 COPY pyproject.toml README.md ./
 COPY src ./src
-# hubcast default logging config
 COPY logging_config.json ./
 
 # create venv and build hubcast and deps
 RUN python -m venv /venv \
  && /venv/bin/pip install --upgrade pip setuptools wheel \
- && /venv/bin/pip install --no-cache-dir /app \
- && rm -rf /root/.cache /tmp/*
+ && /venv/bin/pip install --no-cache-dir /app
 
+FROM python:3.12-alpine
+WORKDIR /app
+
+RUN apk update && apk add --no-cache openldap cyrus-sasl openssl
+
+COPY --from=build /venv /venv
+# hubcast default logging config
+COPY logging_config.json ./
+
+ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
 ENV PATH="/venv/bin:$PATH"
 ENTRYPOINT ["python", "-m", "hubcast"]


### PR DESCRIPTION
Container builds after merging #159 were failing due to a missing gcc for python-ldap
https://github.com/llnl/hubcast/actions/runs/21237609251/job/61108760841#step:6:525.

This PR updates the Dockerfile to add an extra build step with *dev packages in the environment.

Tested this locally.