### PR TITLE
Provide validation feedback to users

### DIFF
--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -94,7 +94,7 @@ Webhook creation requires the GitLab **maintainer** role. In other words, all ch
 
 If changes to Hubcast's configuration are pushed by a user without the maintainer role, Hubcast will continue to mirror commits between the source and destination repository, but any CI status may not be reported back to the source repo.
 
-To resolve this, have a user with the maintainer role push to the default branch; an empty commit is sufficient.
+To resolve this without making changes to the configuration, a user with the maintainer role can push to the default branch with `[hubcast config]` in the commit message; an empty commit is sufficient.
 
 ### Branch protection rules
 

--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -20,15 +20,14 @@ Repo:
   check_name: gitlab-ci
 
   # Optional: granularity of CI statuses reported to GitHub (default: [pipeline])
+  # The overall pipeline status is always reported, in addition to any other types listed here.
   # Available types: pipeline, child-pipelines, jobs
   # You can mix and match any combination of these types
   # Examples:
   #   [pipeline] - overall pipeline status only (default behavior)
-  #   [child-pipelines] - child pipeline statuses only
-  #   [jobs] - individual job statuses only
-  #   [pipeline, child-pipelines] - pipeline and child pipeline statuses
-  #   [pipeline, jobs] - pipeline and job statuses
-  #   [pipeline, child-pipelines, jobs] - all status types
+  #   [child-pipelines] - child pipeline statuses, plus overall pipeline status
+  #   [jobs] - individual job statuses, plus overall pipeline status
+  #   [child-pipelines, jobs] - child pipeline and job statuses, plus overall pipeline status
   check_types: [pipeline]
 
   # Optional: delete branches from destination when source PR is closed (default: true)

--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -5,6 +5,8 @@ import aiohttp
 from gidgethub import HTTPException
 from gidgethub import aiohttp as gh_aiohttp
 
+from hubcast.repos.config import HUBCAST_CONFIG_PATH
+
 from .auth import GitHubAuthenticator
 
 log = logging.getLogger(__name__)
@@ -129,7 +131,7 @@ class GitHubClient:
             gh = gh_aiohttp.GitHubAPI(session, self.requester, oauth_token=gh_token)
 
             # get the contents of the repository hubcast.yml file
-            url = f"/repos/{self.repo_owner}/{self.repo_name}/contents/.github/hubcast.yml"
+            url = f"/repos/{self.repo_owner}/{self.repo_name}/contents/{HUBCAST_CONFIG_PATH}"
             # get raw contents rather than base64 encoded text
             try:
                 return await gh.getitem(url, accept="application/vnd.github.raw")

--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -5,8 +5,6 @@ import aiohttp
 from gidgethub import HTTPException
 from gidgethub import aiohttp as gh_aiohttp
 
-from hubcast.repos.config import HUBCAST_CONFIG_PATH
-
 from .auth import GitHubAuthenticator
 
 log = logging.getLogger(__name__)
@@ -49,6 +47,8 @@ class GitHubClient:
         self.repo_owner = repo_owner
         self.repo_name = repo_name
         self.bot_caller = bot_caller
+        # path to the hubcast config file within a repository, relative to its root
+        self.repo_config_path = ".github/hubcast.yml"
 
     async def set_check_status(
         self,
@@ -131,7 +131,7 @@ class GitHubClient:
             gh = gh_aiohttp.GitHubAPI(session, self.requester, oauth_token=gh_token)
 
             # get the contents of the repository hubcast.yml file
-            url = f"/repos/{self.repo_owner}/{self.repo_name}/contents/{HUBCAST_CONFIG_PATH}"
+            url = f"/repos/{self.repo_owner}/{self.repo_name}/contents/{self.repo_config_path}"
             # get raw contents rather than base64 encoded text
             try:
                 return await gh.getitem(url, accept="application/vnd.github.raw")

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -9,6 +9,7 @@ from hubcast.clients.gitlab.auth import (
     GitLabAuthenticator,
     GitLabSingleUserAuthenticator,
 )
+from hubcast.exceptions import HubcastError, WebhookPermissionError
 from hubcast.webhook import RoutingToken
 
 log = logging.getLogger(__name__)
@@ -182,13 +183,15 @@ class GitLabClient:
                 hooks_data = await gl.getitem(url)
             except gidgetlab.exceptions.BadRequest as exc:
                 if exc.status_code == 403:
-                    log.info(
-                        "User cannot access GitLab webhooks; skipping set_webhook. Must have `maintainer` role."
-                    )
-                    return
+                    raise WebhookPermissionError(
+                        "User cannot access GitLab webhooks; must have `maintainer` role."
+                    ) from exc
                 elif exc.status_code == 401:
-                    log.info("User token is invalid or expired; skipping set_webhook.")
-                    return
+                    # the user never supplies this token; a rejection means
+                    # hubcast's own credential setup is broken
+                    raise HubcastError(
+                        "GitLab rejected hubcast's token while setting webhook - check hubcast's GitLab credentials",
+                    ) from exc
                 raise
 
             existing_hook = None

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -186,6 +186,9 @@ class GitLabClient:
                         "User cannot access GitLab webhooks; skipping set_webhook. Must have `maintainer` role."
                     )
                     return
+                elif exc.status_code == 401:
+                    log.info("User token is invalid or expired; skipping set_webhook.")
+                    return
                 raise
 
             existing_hook = None

--- a/src/hubcast/exceptions.py
+++ b/src/hubcast/exceptions.py
@@ -19,3 +19,21 @@ class HubcastError(Exception):
         logger.log(
             level, str(self), extra={**self.context, **extra_context}, exc_info=exc_info
         )
+
+
+class RepoConfigError(HubcastError):
+    """Raised when a repository's hubcast config is missing or invalid."""
+
+    def __init__(
+        self,
+        message: str,
+        title: str,
+        summary: str,
+        log_level: str = "INFO",
+        **context,
+    ):
+        super().__init__(message, log_level=log_level, **context)
+
+        # store these so route handlers can report the problem back to the user via GH check status
+        self.title = title
+        self.summary = summary

--- a/src/hubcast/exceptions.py
+++ b/src/hubcast/exceptions.py
@@ -37,3 +37,10 @@ class RepoConfigError(HubcastError):
         # store these so route handlers can report the problem back to the user via GH check status
         self.title = title
         self.summary = summary
+
+
+class WebhookPermissionError(HubcastError):
+    """Raised when set_webhook fails because the pusher lacks the GitLab maintainer role."""
+
+    def __init__(self, message: str, log_level: str = "INFO", **context):
+        super().__init__(message, log_level=log_level, **context)

--- a/src/hubcast/repos/config.py
+++ b/src/hubcast/repos/config.py
@@ -46,3 +46,10 @@ class RepoConfig(BaseModel):
 
         # fallback to Pydantic's other validators if the input data isn't a dict
         return data
+
+    @model_validator(mode="after")
+    def require_pipeline_check(self) -> "RepoConfig":
+        """Ensure the "pipeline" check is always enabled, regardless of user config. This is used to pass error messages back to the user."""
+        if "pipeline" not in self.check_types:
+            object.__setattr__(self, "check_types", [*self.check_types, "pipeline"])
+        return self

--- a/src/hubcast/repos/config.py
+++ b/src/hubcast/repos/config.py
@@ -2,9 +2,6 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
-# path to the hubcast config file within a repository, relative to its root
-HUBCAST_CONFIG_PATH = ".github/hubcast.yml"
-
 
 class RepoConfig(BaseModel):
     """Repository configuration for mirroring and status checks"""

--- a/src/hubcast/repos/config.py
+++ b/src/hubcast/repos/config.py
@@ -2,6 +2,9 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
+# path to the hubcast config file within a repository, relative to its root
+HUBCAST_CONFIG_PATH = ".github/hubcast.yml"
+
 
 class RepoConfig(BaseModel):
     """Repository configuration for mirroring and status checks"""

--- a/src/hubcast/web/github/messages.py
+++ b/src/hubcast/web/github/messages.py
@@ -7,7 +7,7 @@ DEACTIVATED_ACCOUNT_MSG = (
     "Your account on the destination GitLab instance is deactivated."
 )
 PERMISSION_DENIED_TITLE = (
-    "Insufficient permissions on destination repository; user must have developer role."
+    "Hubcast couldn't sync your changes due to insufficient permissions."
 )
 PERMISSION_DENIED_DELETE_LOG_MSG = (
     "Failed to delete ref: insufficient permissions on destination repository."
@@ -15,7 +15,7 @@ PERMISSION_DENIED_DELETE_LOG_MSG = (
 PERMISSION_DENIED_SYNC_LOG_MSG = (
     "Failed to sync ref: insufficient permissions on destination repository."
 )
-PERMISSION_DENIED_SUMMARY = 'Hubcast requires all users to have at least the "developer" role on the destination repository. If editing the Hubcast configuration file, users must at least have the "maintainer" role to propagate changes.\nEdit the permission settings and retry.'
+PERMISSION_DENIED_SUMMARY = 'Hubcast requires all users to have at least the "developer" role on the destination repository or have a repository maintainer mirror changes [on your behalf](https://github.com/llnl/hubcast/blob/main/docs/guide-user.md#secure-mirroring).'
 
 # raised by repligit's send_pack when the destination rejects the ref update (e.g. protected branches)
 HOOK_DECLINED_MSG = "pre-receive hook declined"

--- a/src/hubcast/web/github/messages.py
+++ b/src/hubcast/web/github/messages.py
@@ -25,12 +25,24 @@ HOOK_DECLINED_TITLE = (
 HOOK_DECLINED_SUMMARY = f"Hubcast got `{HOOK_DECLINED_MSG}` when pushing changes. In most cases, this happens when a force push is initiated and the destination repository has branch protection rules enabled."
 PIPELINE_FAILED_MSG = "GitLab could not start the pipeline. Investigate the issue in your GitLab CI configuration"
 
+WEBHOOK_PERMISSION_DENIED_TITLE = (
+    "Hubcast couldn't update its configuration due to insufficient permissions."
+)
+WEBHOOK_PERMISSION_DENIED_SUMMARY = 'Hubcast was unable to propagate changes to its configuration due to insufficient permissions on the destination repository. Users who push changes to Hubcast configuration files must have at least the "maintainer" role on the destination repository.\nTo correct this, a user with the maintainer role can push a commit with `[hubcast config]` in the message or a commit with additional changes to the Hubcast configuration file.'
+
 CONFIG_DOCS_URL = (
     "https://github.com/llnl/hubcast/blob/main/docs/guide-user.md#configuration"
 )
 CONFIG_NOT_FOUND_TITLE = "Hubcast configuration file not found."
 CONFIG_NOT_FOUND_SUMMARY = f"Add the configuration file to the default branch and retry. See the [user guide]({CONFIG_DOCS_URL}) for details."
 CONFIG_INVALID_TITLE = "Hubcast configuration file is invalid."
+
+INTERNAL_ERROR_TITLE = "Hubcast internal error"
+INTERNAL_ERROR_SUMMARY = (
+    "Hubcast encountered an internal error while processing this event. "
+    "This is not caused by your repository configuration or permissions. "
+    "Please contact the admins of this Hubcast instance."
+)
 CONFIG_INVALID_SUMMARY = (
     "Hubcast could not parse `.github/hubcast.yml`. "
     f"Fix the configuration file and retry. See the [user guide]({CONFIG_DOCS_URL}) for details."

--- a/src/hubcast/web/github/messages.py
+++ b/src/hubcast/web/github/messages.py
@@ -33,9 +33,6 @@ WEBHOOK_PERMISSION_DENIED_SUMMARY = 'Hubcast was unable to propagate changes to 
 CONFIG_DOCS_URL = (
     "https://github.com/llnl/hubcast/blob/main/docs/guide-user.md#configuration"
 )
-CONFIG_NOT_FOUND_TITLE = "Hubcast configuration file not found."
-CONFIG_NOT_FOUND_SUMMARY = f"Add the configuration file to the default branch and retry. See the [user guide]({CONFIG_DOCS_URL}) for details."
-CONFIG_INVALID_TITLE = "Hubcast configuration file is invalid."
 
 INTERNAL_ERROR_TITLE = "Hubcast internal error"
 INTERNAL_ERROR_SUMMARY = (
@@ -43,6 +40,7 @@ INTERNAL_ERROR_SUMMARY = (
     "This is not caused by your repository configuration or permissions. "
     "Please contact the admins of this Hubcast instance."
 )
+CONFIG_INVALID_TITLE = "Hubcast configuration file is invalid"
 CONFIG_INVALID_SUMMARY = (
     "Hubcast could not parse `.github/hubcast.yml`. "
     f"Fix the configuration file and retry. See the [user guide]({CONFIG_DOCS_URL}) for details."

--- a/src/hubcast/web/github/messages.py
+++ b/src/hubcast/web/github/messages.py
@@ -25,6 +25,17 @@ HOOK_DECLINED_TITLE = (
 HOOK_DECLINED_SUMMARY = f"Hubcast got `{HOOK_DECLINED_MSG}` when pushing changes. In most cases, this happens when a force push is initiated and the destination repository has branch protection rules enabled."
 PIPELINE_FAILED_MSG = "GitLab could not start the pipeline. Investigate the issue in your GitLab CI configuration"
 
+CONFIG_DOCS_URL = (
+    "https://github.com/llnl/hubcast/blob/main/docs/guide-user.md#configuration"
+)
+CONFIG_NOT_FOUND_TITLE = "Hubcast configuration file not found."
+CONFIG_NOT_FOUND_SUMMARY = f"Add the configuration file to the default branch and retry. See the [user guide]({CONFIG_DOCS_URL}) for details."
+CONFIG_INVALID_TITLE = "Hubcast configuration file is invalid."
+CONFIG_INVALID_SUMMARY = (
+    "Hubcast could not parse `.github/hubcast.yml`. "
+    f"Fix the configuration file and retry. See the [user guide]({CONFIG_DOCS_URL}) for details."
+)
+
 
 def help_message(bot_caller: str) -> str:
     return f"""

--- a/src/hubcast/web/github/messages.py
+++ b/src/hubcast/web/github/messages.py
@@ -42,7 +42,7 @@ INTERNAL_ERROR_SUMMARY = (
 )
 CONFIG_INVALID_TITLE = "Hubcast configuration file is invalid"
 CONFIG_INVALID_SUMMARY = (
-    "Hubcast could not parse `.github/hubcast.yml`. "
+    "Hubcast could not parse `hubcast.yml`. "
     f"Fix the configuration file and retry. See the [user guide]({CONFIG_DOCS_URL}) for details."
 )
 

--- a/src/hubcast/web/github/messages.py
+++ b/src/hubcast/web/github/messages.py
@@ -1,0 +1,46 @@
+PERMISSION_DENIED_STATUSES = (
+    401,
+    403,
+)
+DEACTIVATED_ACCOUNT_MARKER = "Your account has been deactivated by your administrator."
+DEACTIVATED_ACCOUNT_MSG = (
+    "Your account on the destination GitLab instance is deactivated."
+)
+PERMISSION_DENIED_TITLE = (
+    "Insufficient permissions on destination repository; user must have developer role."
+)
+PERMISSION_DENIED_DELETE_LOG_MSG = (
+    "Failed to delete ref: insufficient permissions on destination repository."
+)
+PERMISSION_DENIED_SYNC_LOG_MSG = (
+    "Failed to sync ref: insufficient permissions on destination repository."
+)
+PERMISSION_DENIED_SUMMARY = 'Hubcast requires all users to have at least the "developer" role on the destination repository. If editing the Hubcast configuration file, users must at least have the "maintainer" role to propagate changes.\nEdit the permission settings and retry.'
+
+# raised by repligit's send_pack when the destination rejects the ref update (e.g. protected branches)
+HOOK_DECLINED_MSG = "pre-receive hook declined"
+HOOK_DECLINED_TITLE = (
+    "Push to GitLab failed: check branch protection settings and retry."
+)
+HOOK_DECLINED_SUMMARY = f"Hubcast got `{HOOK_DECLINED_MSG}` when pushing changes. In most cases, this happens when a force push is initiated and the destination repository has branch protection rules enabled."
+PIPELINE_FAILED_MSG = "GitLab could not start the pipeline. Investigate the issue in your GitLab CI configuration"
+
+
+def help_message(bot_caller: str) -> str:
+    return f"""
+You can interact with me in many ways!
+
+- `{bot_caller} approve`:
+    - Mirror this PR to the destination repo
+    - Hubcast will perform actions on behalf of the commenter
+    - Must be called using the [GitHub review comment feature](https://github.com/llnl/hubcast/blob/main/docs/guide-user.md#approval)
+- `{bot_caller} restart pipeline`: request a restart of the latest GitLab CI pipeline
+- `{bot_caller} restart failed jobs`: restart any failed jobs in the latest pipeline
+- `{bot_caller} help`: see this message
+
+If you are an outside contributor, a maintainer will need to mirror your changes using the `{bot_caller} approve` command.
+
+A [user guide](https://github.com/llnl/hubcast/blob/main/docs/guide-user.md) is available for additional details on Hubcast's functionality.
+
+For assistance and bug reports, open an issue [here](https://github.com/llnl/hubcast/issues).
+"""

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -9,24 +9,28 @@ from repligit.asyncio import fetch_pack, ls_remote, send_pack
 
 from hubcast.clients.github.client import GitHubClient
 from hubcast.clients.gitlab.client import GitLabClient
-from hubcast.exceptions import HubcastError, RepoConfigError
+from hubcast.exceptions import HubcastError, RepoConfigError, WebhookPermissionError
 from hubcast.logging import update_log_context
-from hubcast.repos.config import RepoConfig
+from hubcast.repos.config import HUBCAST_CONFIG_PATH
 from hubcast.web.github.messages import (
     DEACTIVATED_ACCOUNT_MARKER,
     DEACTIVATED_ACCOUNT_MSG,
     HOOK_DECLINED_MSG,
     HOOK_DECLINED_SUMMARY,
     HOOK_DECLINED_TITLE,
+    INTERNAL_ERROR_SUMMARY,
+    INTERNAL_ERROR_TITLE,
     PERMISSION_DENIED_DELETE_LOG_MSG,
     PERMISSION_DENIED_STATUSES,
     PERMISSION_DENIED_SUMMARY,
     PERMISSION_DENIED_SYNC_LOG_MSG,
     PERMISSION_DENIED_TITLE,
     PIPELINE_FAILED_MSG,
+    WEBHOOK_PERMISSION_DENIED_SUMMARY,
+    WEBHOOK_PERMISSION_DENIED_TITLE,
     help_message,
 )
-from hubcast.web.github.utils import get_repo_config
+from hubcast.web.github.utils import changed_files_from_push, get_repo_config
 
 log = logging.getLogger(__name__)
 
@@ -51,13 +55,19 @@ class GitHubRouter(routing.Router):
 router = GitHubRouter()
 
 
+# check name used to report errors about repo config or webhooks
+# this avoids overwriting errors if a normal pipeline succeeds, and provides
+# a default for situations where there is no default check name set
+# this check won't linger because resolving issues requires a new commit to be pushed
+ERROR_CHECK_NAME = "hubcast-error"
+
+
 async def report_config_error(gh: GitHubClient, sha: str, exc: RepoConfigError) -> None:
     """Report a missing/invalid repo config to the user as a failed check."""
     exc.log(log)
     await gh.set_check_status(
         sha,
-        # config can't be read so default check name is used
-        RepoConfig.model_fields["check_name"].default,
+        ERROR_CHECK_NAME,
         "failure",
         title=exc.title,
         summary=exc.summary,
@@ -91,12 +101,13 @@ async def sync_branch(
         log.info("Skipped branch sync - branch has open PR")
         return
 
-    # only refresh config on default branch pushes (where .github/hubcast.yml lives)
+    # only refresh config when a default branch push touches .github/hubcast.yml
     default_branch = event.data["repository"]["default_branch"]
     is_default_branch = sync_ref == f"refs/heads/{default_branch}"
+    config_changed = HUBCAST_CONFIG_PATH in changed_files_from_push(event.data)
     try:
         repo_config, fetched = await get_repo_config(
-            gh, src_fullname, refresh=is_default_branch
+            gh, src_fullname, refresh=is_default_branch and config_changed
         )
     except RepoConfigError as exc:
         await report_config_error(gh, want_sha, exc)
@@ -104,19 +115,46 @@ async def sync_branch(
 
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
     dest_remote_url = f"{gl.instance_url}/{dest_fullname}.git"
+    commit_msg = event.data.get("head_commit", {}).get("message", "")
 
     # only set/update webhook on default branch pushes when config cache was bypassed (refresh or initial fetch)
-    if fetched and is_default_branch:
+    # and if the config file itself was changed (config_changed above)
+    # we want to give maintainers the option to set the webhook with an empty commit hence the message checking
+    if is_default_branch and (fetched or "[hubcast config]" in commit_msg):
         # setup callback webhook on GitLab
-        await gl.set_webhook(
-            dest_org=repo_config.dest_org,
-            dest_repo=repo_config.dest_name,
-            gh_owner=src_owner,
-            gh_repo=src_repo_name,
-            gh_check=repo_config.check_name,
-            check_types=repo_config.check_types,
-        )
-        log.info("Updated GitLab webhook", extra={"dest_fullname": dest_fullname})
+        try:
+            await gl.set_webhook(
+                dest_org=repo_config.dest_org,
+                dest_repo=repo_config.dest_name,
+                gh_owner=src_owner,
+                gh_repo=src_repo_name,
+                gh_check=repo_config.check_name,
+                check_types=repo_config.check_types,
+            )
+        except WebhookPermissionError as exc:
+            # the user is not a maintainer and we need to tell them to push config changes with higher permissions
+            exc.log(log)
+            await gh.set_check_status(
+                want_sha,
+                ERROR_CHECK_NAME,
+                "failure",
+                title=WEBHOOK_PERMISSION_DENIED_TITLE,
+                summary=WEBHOOK_PERMISSION_DENIED_SUMMARY,
+            )
+            return
+        except HubcastError as exc:
+            # log for the hubcast admin and tell the user it's not their fault
+            exc.log(log)
+            await gh.set_check_status(
+                want_sha,
+                ERROR_CHECK_NAME,
+                "failure",
+                title=INTERNAL_ERROR_TITLE,
+                summary=INTERNAL_ERROR_SUMMARY,
+            )
+            return
+        else:
+            log.info("Updated GitLab webhook", extra={"dest_fullname": dest_fullname})
 
     # sync commits from GitHub -> GitLab
     gl_token = await gl.auth.authenticate_user(gl_user)

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -12,7 +12,6 @@ from hubcast.clients.github.client import GitHubClient
 from hubcast.clients.gitlab.client import GitLabClient
 from hubcast.exceptions import HubcastError, RepoConfigError, WebhookPermissionError
 from hubcast.logging import update_log_context
-from hubcast.repos.config import HUBCAST_CONFIG_PATH
 from hubcast.web.github.messages import (
     DEACTIVATED_ACCOUNT_MARKER,
     DEACTIVATED_ACCOUNT_MSG,
@@ -105,7 +104,7 @@ async def sync_branch(
     # only refresh config when a default branch push touches .github/hubcast.yml
     default_branch = event.data["repository"]["default_branch"]
     is_default_branch = sync_ref == f"refs/heads/{default_branch}"
-    config_changed = HUBCAST_CONFIG_PATH in changed_files_from_push(event.data)
+    config_changed = gh.repo_config_path in changed_files_from_push(event.data)
     try:
         repo_config, fetched = await get_repo_config(
             gh, src_fullname, refresh=is_default_branch and config_changed

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -119,7 +119,8 @@ async def sync_branch(
 
     # only set/update webhook on default branch pushes when config cache was bypassed (refresh or initial fetch)
     # and if the config file itself was changed (config_changed above)
-    # we want to give maintainers the option to set the webhook with an empty commit hence the message checking
+    # we want to give maintainers the option to force-set the webhook; an empty commit won't result in a cache miss
+    # if the commit message contains [hubcast config], we'll set the webhook
     if is_default_branch and (fetched or "[hubcast config]" in commit_msg):
         # setup callback webhook on GitLab
         try:

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -6,6 +6,7 @@ from aiohttp.client_exceptions import ClientResponseError
 from gidgethub import routing, sansio
 from gidgetlab.exceptions import BadRequest
 from repligit.asyncio import fetch_pack, ls_remote, send_pack
+from repligit.exceptions import RefUpdateRejected
 
 from hubcast.clients.github.client import GitHubClient
 from hubcast.clients.gitlab.client import GitLabClient
@@ -222,16 +223,17 @@ async def sync_branch(
         )
         return
     # repligit
-    except Exception as exc:
-        if str(exc) != HOOK_DECLINED_MSG:
-            raise
+    except RefUpdateRejected as exc:
+        hook_declined = str(exc) == HOOK_DECLINED_MSG
         await gh.set_check_status(
             want_sha,
             repo_config.check_name,
             "failure",
-            title=HOOK_DECLINED_TITLE,
-            summary=HOOK_DECLINED_SUMMARY,
+            title=HOOK_DECLINED_TITLE if hook_declined else INTERNAL_ERROR_TITLE,
+            summary=HOOK_DECLINED_SUMMARY if hook_declined else INTERNAL_ERROR_SUMMARY,
         )
+        if not hook_declined:
+            raise
         return
 
     log.info("Synced branch")
@@ -293,8 +295,9 @@ async def remove_branch(
         log.info(PERMISSION_DENIED_DELETE_LOG_MSG)
         return
     # repligit
-    except Exception as exc:
+    except RefUpdateRejected as exc:
         if str(exc) != HOOK_DECLINED_MSG:
+            # raise unknown ref update rejected errors for later debugging
             raise
         log.info(str(exc))
         return
@@ -440,16 +443,19 @@ async def sync_pr(
             )
             return
         # repligit
-        except Exception as exc:
-            if str(exc) != HOOK_DECLINED_MSG:
-                raise
+        except RefUpdateRejected as exc:
+            hook_declined = str(exc) == HOOK_DECLINED_MSG
             await gh.set_check_status(
                 want_sha,
                 repo_config.check_name,
                 "failure",
-                title=HOOK_DECLINED_TITLE,
-                summary=HOOK_DECLINED_SUMMARY,
+                title=HOOK_DECLINED_TITLE if hook_declined else INTERNAL_ERROR_TITLE,
+                summary=HOOK_DECLINED_SUMMARY
+                if hook_declined
+                else INTERNAL_ERROR_SUMMARY,
             )
+            if not hook_declined:
+                raise
             return
 
         log.info("Synced PR")
@@ -571,7 +577,7 @@ async def remove_pr(
         log.info(PERMISSION_DENIED_DELETE_LOG_MSG)
         return
     # repligit
-    except Exception as exc:
+    except RefUpdateRejected as exc:
         if str(exc) != HOOK_DECLINED_MSG:
             raise
         log.info(str(exc))

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -2,14 +2,29 @@ import logging
 import re
 from typing import Any
 
+from aiohttp.client_exceptions import ClientResponseError
 from gidgethub import routing, sansio
+from gidgetlab.exceptions import BadRequest
 from repligit.asyncio import fetch_pack, ls_remote, send_pack
 
 from hubcast.clients.github.client import GitHubClient
 from hubcast.clients.gitlab.client import GitLabClient
 from hubcast.exceptions import HubcastError
 from hubcast.logging import update_log_context
-from hubcast.web import comments
+from hubcast.web.github.messages import (
+    DEACTIVATED_ACCOUNT_MARKER,
+    DEACTIVATED_ACCOUNT_MSG,
+    HOOK_DECLINED_MSG,
+    HOOK_DECLINED_SUMMARY,
+    HOOK_DECLINED_TITLE,
+    PERMISSION_DENIED_DELETE_LOG_MSG,
+    PERMISSION_DENIED_STATUSES,
+    PERMISSION_DENIED_SUMMARY,
+    PERMISSION_DENIED_SYNC_LOG_MSG,
+    PERMISSION_DENIED_TITLE,
+    PIPELINE_FAILED_MSG,
+    help_message,
+)
 from hubcast.web.github.utils import get_repo_config
 
 log = logging.getLogger(__name__)
@@ -88,7 +103,21 @@ async def sync_branch(
     # sync commits from GitHub -> GitLab
     gl_token = await gl.auth.authenticate_user(gl_user)
 
-    gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)
+    try:
+        gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)
+    except ClientResponseError as exc:
+        if exc.status not in PERMISSION_DENIED_STATUSES:
+            raise
+        log.info(PERMISSION_DENIED_SYNC_LOG_MSG)
+        await gh.set_check_status(
+            want_sha,
+            repo_config.check_name,
+            "failure",
+            title=PERMISSION_DENIED_TITLE,
+            summary=PERMISSION_DENIED_SUMMARY,
+        )
+        return
+
     have_shas = set(gl_refs.values())
     from_sha = gl_refs.get(sync_ref) or ("0" * 40)
 
@@ -109,16 +138,45 @@ async def sync_branch(
         username=gh.requester,  # the username doesn't matter, but can't be empty
         password=gh_token,
     )
+    if packfile is None:
+        raise HubcastError(
+            f"Failed to fetch packfile for {want_sha} from {src_repo_url}"
+        )
 
-    await send_pack(
-        dest_remote_url,
-        sync_ref,
-        from_sha,
-        want_sha,
-        packfile,
-        username=gl_user,
-        password=gl_token,
-    )
+    try:
+        await send_pack(
+            dest_remote_url,
+            sync_ref,
+            from_sha,
+            want_sha,
+            packfile,
+            username=gl_user,
+            password=gl_token,
+        )
+    except ClientResponseError as exc:
+        if exc.status not in PERMISSION_DENIED_STATUSES:
+            raise
+        log.info(PERMISSION_DENIED_SYNC_LOG_MSG)
+        await gh.set_check_status(
+            want_sha,
+            repo_config.check_name,
+            "failure",
+            title=PERMISSION_DENIED_TITLE,
+            summary=PERMISSION_DENIED_SUMMARY,
+        )
+        return
+    # repligit
+    except Exception as exc:
+        if str(exc) != HOOK_DECLINED_MSG:
+            raise
+        await gh.set_check_status(
+            want_sha,
+            repo_config.check_name,
+            "failure",
+            title=HOOK_DECLINED_TITLE,
+            summary=HOOK_DECLINED_SUMMARY,
+        )
+        return
 
     log.info("Synced branch")
 
@@ -142,7 +200,15 @@ async def remove_branch(
 
     gl_token = await gl.auth.authenticate_user(gl_user)
 
-    gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)
+    try:
+        gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)
+    except ClientResponseError as exc:
+        if exc.status not in PERMISSION_DENIED_STATUSES:
+            raise
+        # we cannot set GitHub status checks for deleted refs, and we have no way to notify the user of this failure
+        log.info(PERMISSION_DENIED_DELETE_LOG_MSG)
+        return
+
     head_sha = gl_refs.get(sync_ref)
 
     update_log_context(ref=sync_ref, head_sha=head_sha)
@@ -155,15 +221,27 @@ async def remove_branch(
 
     log.info("Deleting branch")
 
-    await send_pack(
-        dest_remote_url,
-        sync_ref,
-        head_sha,
-        null_sha,
-        b"",
-        username=gl_user,
-        password=gl_token,
-    )
+    try:
+        await send_pack(
+            dest_remote_url,
+            sync_ref,
+            head_sha,
+            null_sha,
+            b"",
+            username=gl_user,
+            password=gl_token,
+        )
+    except ClientResponseError as exc:
+        if exc.status not in PERMISSION_DENIED_STATUSES:
+            raise
+        log.info(PERMISSION_DENIED_DELETE_LOG_MSG)
+        return
+    # repligit
+    except Exception as exc:
+        if str(exc) != HOOK_DECLINED_MSG:
+            raise
+        log.info(str(exc))
+        return
 
     log.info("Deleted branch")
 
@@ -219,7 +297,7 @@ async def sync_pr(
         if repo_config.sync_drafts_msg:
             await gh.set_check_status(
                 want_sha,
-                repo_config.check_name or "hubcast",
+                repo_config.check_name,
                 status="skipped",
                 title="Hubcast disables sync for draft PRs.",
             )
@@ -230,7 +308,21 @@ async def sync_pr(
     dest_remote_url = f"{gl.instance_url}/{dest_fullname}.git"
     gl_token = await gl.auth.authenticate_user(gl_user)
 
-    gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)
+    try:
+        gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)
+    except ClientResponseError as exc:
+        if exc.status not in PERMISSION_DENIED_STATUSES:
+            raise
+        log.info(PERMISSION_DENIED_SYNC_LOG_MSG)
+        await gh.set_check_status(
+            want_sha,
+            repo_config.check_name,
+            "failure",
+            title=PERMISSION_DENIED_TITLE,
+            summary=PERMISSION_DENIED_SUMMARY,
+        )
+        return
+
     have_shas = set(gl_refs.values())
     from_sha = gl_refs.get(sync_ref) or ("0" * 40)
     update_log_context(from_sha=from_sha, want_sha=want_sha)
@@ -257,18 +349,47 @@ async def sync_pr(
             have_shas,
             **src_creds,
         )
+        if packfile is None:
+            raise HubcastError(
+                f"Failed to fetch packfile for {want_sha} from {src_repo_url}"
+            )
 
         # upload packfile to gitlab repository
         log.info("Syncing PR")
-        await send_pack(
-            dest_remote_url,
-            sync_ref,
-            from_sha,
-            want_sha,
-            packfile,
-            username=gl_user,
-            password=gl_token,
-        )
+        try:
+            await send_pack(
+                dest_remote_url,
+                sync_ref,
+                from_sha,
+                want_sha,
+                packfile,
+                username=gl_user,
+                password=gl_token,
+            )
+        except ClientResponseError as exc:
+            if exc.status not in PERMISSION_DENIED_STATUSES:
+                raise
+            log.info(PERMISSION_DENIED_SYNC_LOG_MSG)
+            await gh.set_check_status(
+                want_sha,
+                repo_config.check_name,
+                "failure",
+                title=PERMISSION_DENIED_TITLE,
+                summary=PERMISSION_DENIED_SUMMARY,
+            )
+            return
+        # repligit
+        except Exception as exc:
+            if str(exc) != HOOK_DECLINED_MSG:
+                raise
+            await gh.set_check_status(
+                want_sha,
+                repo_config.check_name,
+                "failure",
+                title=HOOK_DECLINED_TITLE,
+                summary=HOOK_DECLINED_SUMMARY,
+            )
+            return
 
         log.info("Synced PR")
 
@@ -276,6 +397,7 @@ async def sync_pr(
     if repo_config.create_mr and not await gl.get_mr(
         dest_fullname, sync_branch, default_branch
     ):
+        # user must have at least developer role to reach this point so we don't need to do a permissions check
         await gl.create_mr(
             gl_fullname=dest_fullname,
             src_branch=sync_branch,
@@ -355,7 +477,15 @@ async def remove_pr(
     dest_remote_url = f"{gl.instance_url}/{dest_fullname}.git"
     gl_token = await gl.auth.authenticate_user(gl_user)
 
-    gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)
+    try:
+        gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)
+    except ClientResponseError as exc:
+        if exc.status not in PERMISSION_DENIED_STATUSES:
+            raise
+        # we cannot set GitHub status checks for deleted refs, and we have no way to notify the user of this failure
+        log.info(PERMISSION_DENIED_DELETE_LOG_MSG)
+        return
+
     head_sha = gl_refs.get(sync_ref)
     if head_sha is None:
         log.info("Skipped PR branch removal - ref not found")
@@ -364,15 +494,27 @@ async def remove_pr(
     null_sha = "0" * 40
 
     log.info("Deleting PR branch")
-    await send_pack(
-        dest_remote_url,
-        sync_ref,
-        head_sha,
-        null_sha,
-        b"",
-        username=gl_user,
-        password=gl_token,
-    )
+    try:
+        await send_pack(
+            dest_remote_url,
+            sync_ref,
+            head_sha,
+            null_sha,
+            b"",
+            username=gl_user,
+            password=gl_token,
+        )
+    except ClientResponseError as exc:
+        if exc.status not in PERMISSION_DENIED_STATUSES:
+            raise
+        log.info(PERMISSION_DENIED_DELETE_LOG_MSG)
+        return
+    # repligit
+    except Exception as exc:
+        if str(exc) != HOOK_DECLINED_MSG:
+            raise
+        log.info(str(exc))
+        return
 
     log.info("Deleted PR branch")
 
@@ -440,7 +582,7 @@ async def respond_comment(
     action_logged = False
 
     if re.search(f"{gh.bot_caller} help", comment, re.IGNORECASE):
-        response = comments.help_message(gh.bot_caller)
+        response = help_message(gh.bot_caller)
         log.info("Help message sent")
         action_logged = True
 
@@ -462,6 +604,7 @@ async def respond_comment(
         # this process will not sync changes, as an external collaborator could
         # submit malicious changes and trigger a sync without explicit approval
         # on the commit hash (see `respond_pr_comment`)
+        action_logged = True
         pull_request_id = event.data["issue"]["number"]
         pull_request = await gh.get_pr(pull_request_id)
 
@@ -483,17 +626,27 @@ async def respond_comment(
         # get the gitlab repo information and run the pipeline
         repo_config, _ = await get_repo_config(gh, base_fullname)
         dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
-        pipeline_url = await gl.run_pipeline(dest_fullname, branch)
 
-        if pipeline_url:
+        try:
+            pipeline_url = await gl.run_pipeline(dest_fullname, branch)
+        except BadRequest as exc:
+            if exc.status_code in PERMISSION_DENIED_STATUSES:
+                response = (
+                    DEACTIVATED_ACCOUNT_MSG
+                    if DEACTIVATED_ACCOUNT_MARKER in str(exc)
+                    else PERMISSION_DENIED_SUMMARY
+                )
+                log.info("Pipeline failed to start - insufficient permissions")
+            elif exc.status_code == 400:
+                # \n to avoid indent markdown issues
+                response = f"""{PIPELINE_FAILED_MSG}\n```\n{exc}\n```"""
+                log.info("Pipeline failed to start", extra={"error": exc})
+            else:
+                raise
+        else:
             response = f"I've started a new [pipeline]({pipeline_url}) for you!"
             plus_one = True
             log.info("Pipeline started for branch")
-            action_logged = True
-        else:
-            response = "I had a problem starting the pipeline."
-            log.info("Pipeline failed to start for branch")
-            action_logged = True
 
     elif re.search(
         f"{gh.bot_caller} restart failed(?:[- ]?jobs)?", comment, re.IGNORECASE
@@ -501,6 +654,7 @@ async def respond_comment(
         # if a pipeline failed, we give the user the option to restart any failed jobs
         # we don't want to re-sync the branch, as a new pipeline would be created
         # and would defeat the purpose of individually restarting failed jobs
+        action_logged = True
         pull_request_id = event.data["issue"]["number"]
         pull_request = await gh.get_pr(pull_request_id)
 
@@ -521,26 +675,40 @@ async def respond_comment(
         # get the gitlab repo information and run the pipeline
         repo_config, _ = await get_repo_config(gh, base_fullname)
         dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
-        pipeline_id = await gl.get_latest_pipeline(dest_fullname, branch)
 
-        if pipeline_id:
-            pipeline_url = await gl.retry_pipeline_jobs(dest_fullname, pipeline_id)
-
-            if pipeline_url:
-                response = (
-                    f"I've retried any failed jobs in the [pipeline]({pipeline_url})!"
-                )
-                plus_one = True
-                log.info("Jobs restarted for branch")
-                action_logged = True
-            else:
-                response = "I had a problem retrying jobs in the pipeline."
-                log.info("Jobs restart failed for branch")
-                action_logged = True
+        try:
+            pipeline_id = await gl.get_latest_pipeline(dest_fullname, branch)
+        except BadRequest as exc:
+            if exc.status_code not in PERMISSION_DENIED_STATUSES:
+                raise
+            response = (
+                DEACTIVATED_ACCOUNT_MSG
+                if DEACTIVATED_ACCOUNT_MARKER in str(exc)
+                else PERMISSION_DENIED_SUMMARY
+            )
+            log.info("Pipeline ID fetch failed - insufficient permissions")
         else:
-            response = "No pipeline exists."
-            log.info("No pipeline found for branch")
-            action_logged = True
+            if pipeline_id:
+                try:
+                    pipeline_url = await gl.retry_pipeline_jobs(
+                        dest_fullname, pipeline_id
+                    )
+                except BadRequest as exc:
+                    if exc.status_code not in PERMISSION_DENIED_STATUSES:
+                        raise
+                    response = (
+                        DEACTIVATED_ACCOUNT_MSG
+                        if DEACTIVATED_ACCOUNT_MARKER in str(exc)
+                        else PERMISSION_DENIED_SUMMARY
+                    )
+                    log.info("Jobs restart failed - insufficient permissions")
+                else:
+                    response = f"I've retried any failed jobs in the [pipeline]({pipeline_url})!"
+                    plus_one = True
+                    log.info("Jobs restarted for branch")
+            else:
+                response = "No pipeline exists."
+                log.info("No pipeline found for branch")
 
     if response:
         await gh.post_comment(event.data["issue"]["number"], response)
@@ -588,7 +756,29 @@ async def rerun_check(
     # get the GL repo info and run the pipeline
     repo_config, _ = await get_repo_config(gh, src_fullname)
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
-    await gl.run_pipeline(dest_fullname, branch)
+
+    try:
+        await gl.run_pipeline(dest_fullname, branch)
+    except BadRequest as exc:
+        if exc.status_code in PERMISSION_DENIED_STATUSES:
+            deactivated = DEACTIVATED_ACCOUNT_MARKER in str(exc)
+            message = (
+                DEACTIVATED_ACCOUNT_MSG if deactivated else PERMISSION_DENIED_TITLE
+            )
+            summary = "" if deactivated else PERMISSION_DENIED_SUMMARY
+        elif exc.status_code == 400:
+            message = PIPELINE_FAILED_MSG
+            summary = str(exc)
+        else:
+            raise
+        await gh.set_check_status(
+            check_run_commit,
+            repo_config.check_name,
+            "failure",
+            title=message,
+            summary=summary,
+        )
+        return
 
     log.info(
         "Rerun check requested for branch",

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -9,8 +9,9 @@ from repligit.asyncio import fetch_pack, ls_remote, send_pack
 
 from hubcast.clients.github.client import GitHubClient
 from hubcast.clients.gitlab.client import GitLabClient
-from hubcast.exceptions import HubcastError
+from hubcast.exceptions import HubcastError, RepoConfigError
 from hubcast.logging import update_log_context
+from hubcast.repos.config import RepoConfig
 from hubcast.web.github.messages import (
     DEACTIVATED_ACCOUNT_MARKER,
     DEACTIVATED_ACCOUNT_MSG,
@@ -50,6 +51,19 @@ class GitHubRouter(routing.Router):
 router = GitHubRouter()
 
 
+async def report_config_error(gh: GitHubClient, sha: str, exc: RepoConfigError) -> None:
+    """Report a missing/invalid repo config to the user as a failed check."""
+    exc.log(log)
+    await gh.set_check_status(
+        sha,
+        # config can't be read so default check name is used
+        RepoConfig.model_fields["check_name"].default,
+        "failure",
+        title=exc.title,
+        summary=exc.summary,
+    )
+
+
 # -----------------------------------
 # Push Events
 # -----------------------------------
@@ -80,9 +94,13 @@ async def sync_branch(
     # only refresh config on default branch pushes (where .github/hubcast.yml lives)
     default_branch = event.data["repository"]["default_branch"]
     is_default_branch = sync_ref == f"refs/heads/{default_branch}"
-    repo_config, fetched = await get_repo_config(
-        gh, src_fullname, refresh=is_default_branch
-    )
+    try:
+        repo_config, fetched = await get_repo_config(
+            gh, src_fullname, refresh=is_default_branch
+        )
+    except RepoConfigError as exc:
+        await report_config_error(gh, want_sha, exc)
+        return
 
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
     dest_remote_url = f"{gl.instance_url}/{dest_fullname}.git"
@@ -292,7 +310,12 @@ async def sync_pr(
         return
 
     # get the repository configuration from .github/hubcast.yml
-    repo_config, _ = await get_repo_config(gh, base_fullname)
+    try:
+        repo_config, _ = await get_repo_config(gh, base_fullname)
+    except RepoConfigError as exc:
+        await report_config_error(gh, want_sha, exc)
+        return
+
     if not repo_config.sync_drafts and pull_request["draft"]:
         if repo_config.sync_drafts_msg:
             await gh.set_check_status(
@@ -754,7 +777,12 @@ async def rerun_check(
         return
 
     # get the GL repo info and run the pipeline
-    repo_config, _ = await get_repo_config(gh, src_fullname)
+    try:
+        repo_config, _ = await get_repo_config(gh, src_fullname)
+    except RepoConfigError as exc:
+        await report_config_error(gh, check_run_commit, exc)
+        return
+
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
 
     try:

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -4,8 +4,14 @@ import yaml
 from cachetools import TTLCache
 
 from hubcast.clients.github import GitHubClient
-from hubcast.exceptions import HubcastError
+from hubcast.exceptions import RepoConfigError
 from hubcast.repos.config import RepoConfig
+from hubcast.web.github.messages import (
+    CONFIG_INVALID_SUMMARY,
+    CONFIG_INVALID_TITLE,
+    CONFIG_NOT_FOUND_SUMMARY,
+    CONFIG_NOT_FOUND_TITLE,
+)
 
 log = logging.getLogger(__name__)
 
@@ -36,9 +42,10 @@ async def get_repo_config(
         log.info("Repo config retrieved from cache")
         if config is None:
             # raise so route handlers can't continue
-            raise HubcastError(
-                "Config file not found",
-                log_level="INFO",
+            raise RepoConfigError(
+                "Repo config file not found",
+                title=CONFIG_NOT_FOUND_TITLE,
+                summary=CONFIG_NOT_FOUND_SUMMARY,
             )
         return config, False
 
@@ -49,26 +56,31 @@ async def get_repo_config(
         config_cache[fullname] = None
         log.info("Cached absence of repo config")
         # raise so route handlers can't continue
-        raise HubcastError(
+        raise RepoConfigError(
             "Repo config file not found",
-            log_level="INFO",
+            title=CONFIG_NOT_FOUND_TITLE,
+            summary=CONFIG_NOT_FOUND_SUMMARY,
         )
 
     # parse and validate YAML
     try:
         config_yaml = yaml.safe_load(fetched_config)
     except yaml.YAMLError as e:
-        raise HubcastError(
-            f"Invalid YAML in repo config for {fullname}: {e}",
-            log_level="INFO",
+        raise RepoConfigError(
+            "Invalid YAML in repo config",
+            title=CONFIG_INVALID_TITLE,
+            summary=CONFIG_INVALID_SUMMARY,
+            error=str(e),
         )
 
     try:
         config = RepoConfig.model_validate(config_yaml)
     except ValueError as e:
-        raise HubcastError(
-            f"Invalid repo config for {fullname}: {e}",
-            log_level="INFO",
+        raise RepoConfigError(
+            "Invalid repo config",
+            title=CONFIG_INVALID_TITLE,
+            summary=CONFIG_INVALID_SUMMARY,
+            error=str(e),
         )
 
     config_cache[fullname] = config

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import yaml
 from cachetools import TTLCache
@@ -17,6 +18,16 @@ log = logging.getLogger(__name__)
 
 # Shared cache for repository configs with 30-minute TTL
 config_cache: TTLCache[str, RepoConfig | None] = TTLCache(maxsize=1000, ttl=1800)
+
+
+def changed_files_from_push(payload: dict[str, Any]) -> set[str]:
+    """Collect all file paths touched by the commits in a push payload."""
+    return {
+        f
+        for c in payload["commits"]
+        for key in ("added", "modified", "removed")
+        for f in c.get(key, ())
+    }
 
 
 async def get_repo_config(

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -5,13 +5,11 @@ import yaml
 from cachetools import TTLCache
 
 from hubcast.clients.github import GitHubClient
-from hubcast.exceptions import RepoConfigError
+from hubcast.exceptions import HubcastError, RepoConfigError
 from hubcast.repos.config import RepoConfig
 from hubcast.web.github.messages import (
     CONFIG_INVALID_SUMMARY,
     CONFIG_INVALID_TITLE,
-    CONFIG_NOT_FOUND_SUMMARY,
-    CONFIG_NOT_FOUND_TITLE,
 )
 
 log = logging.getLogger(__name__)
@@ -53,11 +51,9 @@ async def get_repo_config(
         log.info("Repo config retrieved from cache")
         if config is None:
             # raise so route handlers can't continue
-            raise RepoConfigError(
-                "Repo config file not found",
-                title=CONFIG_NOT_FOUND_TITLE,
-                summary=CONFIG_NOT_FOUND_SUMMARY,
-            )
+            # we don't want to raise this as a RepoConfigError because telling users
+            # about the absence of the config will create noise and confusion
+            raise HubcastError("Repo config file not found", log_level="INFO")
         return config, False
 
     # cache miss or refresh requested, fetch from GH
@@ -67,11 +63,7 @@ async def get_repo_config(
         config_cache[fullname] = None
         log.info("Cached absence of repo config")
         # raise so route handlers can't continue
-        raise RepoConfigError(
-            "Repo config file not found",
-            title=CONFIG_NOT_FOUND_TITLE,
-            summary=CONFIG_NOT_FOUND_SUMMARY,
-        )
+        raise HubcastError("Repo config file not found", log_level="INFO")
 
     # parse and validate YAML
     try:

--- a/tests/test_github_routes.py
+++ b/tests/test_github_routes.py
@@ -33,6 +33,9 @@ def mock_push_event():
         "after": "sha-123",
         "head_commit": {"id": "sha-123"},
         "ref": "refs/heads/main",
+        "commits": [
+            {"added": [], "modified": ["src/app.py"], "removed": []},
+        ],
     }
     return event
 

--- a/tests/test_github_routes.py
+++ b/tests/test_github_routes.py
@@ -235,22 +235,14 @@ def setup_pr_mocks(mock_gh, mock_repligit_ops):
 def setup_pipeline_mocks(mock_gl):
     """Configure mocks for pipeline operations."""
 
-    def _setup(run_success=True, pipeline_exists=True, retry_success=True):
-        if run_success:
-            mock_gl.run_pipeline = AsyncMock(
-                return_value="https://gitlab.com/pipeline/123"
-            )
-        else:
-            mock_gl.run_pipeline = AsyncMock(return_value=None)
+    def _setup(pipeline_exists=True):
+        mock_gl.run_pipeline = AsyncMock(return_value="https://gitlab.com/pipeline/123")
 
         if pipeline_exists:
             mock_gl.get_latest_pipeline = AsyncMock(return_value=789)
-            if retry_success:
-                mock_gl.retry_pipeline_jobs = AsyncMock(
-                    return_value="https://gitlab.com/pipeline/789"
-                )
-            else:
-                mock_gl.retry_pipeline_jobs = AsyncMock(return_value=None)
+            mock_gl.retry_pipeline_jobs = AsyncMock(
+                return_value="https://gitlab.com/pipeline/789"
+            )
         else:
             mock_gl.get_latest_pipeline = AsyncMock(return_value=None)
 
@@ -728,26 +720,18 @@ async def test_respond_comment_run_pipeline(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "is_internal,run_success,expected_log,expected_branch",
+    "is_internal,expected_log,expected_branch",
     [
         (
-            True,
             True,
             "Pipeline started for branch",
             "feature-branch",
         ),  # internal PR success
-        (False, True, "Pipeline started for branch", "pr-123"),  # fork PR success
-        (
-            True,
-            False,
-            "Pipeline failed to start for branch",
-            "feature-branch",
-        ),  # internal PR failed
+        (False, "Pipeline started for branch", "pr-123"),  # fork PR success
     ],
 )
 async def test_respond_comment_run_pipeline_variations(
     is_internal,
-    run_success,
     expected_log,
     expected_branch,
     mock_comment_event,
@@ -767,7 +751,7 @@ async def test_respond_comment_run_pipeline_variations(
         mock_pr_data_for_comment["head"]["ref"] = "feature-branch"
 
     setup_pr_mocks(mock_pr_data_for_comment)
-    setup_pipeline_mocks(run_success=run_success)
+    setup_pipeline_mocks()
 
     await respond_comment(
         event=mock_comment_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
@@ -817,26 +801,17 @@ async def test_respond_comment_restart_jobs(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "is_internal,pipeline_exists,retry_success,expected_log,expected_branch",
+    "is_internal,pipeline_exists,expected_log,expected_branch",
     [
         (
-            True,
             True,
             True,
             "Jobs restarted for branch",
             "feature-branch",
         ),  # internal success
-        (False, True, True, "Jobs restarted for branch", "pr-123"),  # fork success
+        (False, True, "Jobs restarted for branch", "pr-123"),  # fork success
         (
             True,
-            True,
-            False,
-            "Jobs restart failed for branch",
-            "feature-branch",
-        ),  # retry failed
-        (
-            True,
-            False,
             False,
             "No pipeline found for branch",
             "feature-branch",
@@ -846,7 +821,6 @@ async def test_respond_comment_restart_jobs(
 async def test_respond_comment_restart_jobs_variations(
     is_internal,
     pipeline_exists,
-    retry_success,
     expected_log,
     expected_branch,
     mock_comment_event,
@@ -866,7 +840,7 @@ async def test_respond_comment_restart_jobs_variations(
         mock_pr_data_for_comment["head"]["ref"] = "feature-branch"
 
     setup_pr_mocks(mock_pr_data_for_comment)
-    setup_pipeline_mocks(pipeline_exists=pipeline_exists, retry_success=retry_success)
+    setup_pipeline_mocks(pipeline_exists=pipeline_exists)
 
     await respond_comment(
         event=mock_comment_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"

--- a/tests/test_github_routes.py
+++ b/tests/test_github_routes.py
@@ -1,12 +1,34 @@
 # tests for Hubcast's GitHub route handlers
 
+from collections.abc import Callable
+from http import HTTPStatus
+from typing import NamedTuple
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from aiohttp.client_exceptions import ClientResponseError
 from gidgethub import sansio
+from gidgetlab.exceptions import BadRequest
 
-from hubcast.exceptions import HubcastError
+from hubcast.exceptions import HubcastError, RepoConfigError, WebhookPermissionError
+from hubcast.web.github.messages import (
+    DEACTIVATED_ACCOUNT_MARKER,
+    DEACTIVATED_ACCOUNT_MSG,
+    HOOK_DECLINED_MSG,
+    HOOK_DECLINED_SUMMARY,
+    HOOK_DECLINED_TITLE,
+    INTERNAL_ERROR_SUMMARY,
+    INTERNAL_ERROR_TITLE,
+    PERMISSION_DENIED_DELETE_LOG_MSG,
+    PERMISSION_DENIED_SUMMARY,
+    PERMISSION_DENIED_SYNC_LOG_MSG,
+    PERMISSION_DENIED_TITLE,
+    PIPELINE_FAILED_MSG,
+    WEBHOOK_PERMISSION_DENIED_SUMMARY,
+    WEBHOOK_PERMISSION_DENIED_TITLE,
+)
 from hubcast.web.github.routes import (
+    ERROR_CHECK_NAME,
     remove_branch,
     remove_pr,
     rerun_check,
@@ -16,6 +38,18 @@ from hubcast.web.github.routes import (
     sync_branch,
     sync_pr_event,
 )
+
+
+def permission_error(status: int = 403) -> ClientResponseError:
+    """Build the aiohttp error repligit raises on HTTP failures."""
+    return ClientResponseError(request_info=Mock(), history=(), status=status)
+
+
+def repo_config_error() -> RepoConfigError:
+    return RepoConfigError(
+        "Invalid repo config", title="config title", summary="config summary"
+    )
+
 
 ### FIXTURES
 
@@ -31,7 +65,7 @@ def mock_push_event():
             "default_branch": "main",
         },
         "after": "sha-123",
-        "head_commit": {"id": "sha-123"},
+        "head_commit": {"id": "sha-123", "message": "update app"},
         "ref": "refs/heads/main",
         "commits": [
             {"added": [], "modified": ["src/app.py"], "removed": []},
@@ -197,6 +231,8 @@ def mock_repligit_ops():
             sync_drafts=True,
             sync_drafts_msg=True,
             delete_closed=True,
+            check_name="hubcast",
+            check_types=["pipeline"],
         )
         mock_get_config.return_value = (default_config, True)
 
@@ -353,6 +389,118 @@ async def test_sync_branch_synced(
     assert "Synced branch" in caplog.text
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "ref,modified,expected_refresh",
+    [
+        ("refs/heads/main", [".github/hubcast.yml"], True),
+        ("refs/heads/main", ["src/app.py"], False),
+        ("refs/heads/feature", [".github/hubcast.yml"], False),
+    ],
+)
+async def test_sync_branch_config_refresh(
+    ref,
+    modified,
+    expected_refresh,
+    mock_push_event,
+    mock_gh,
+    mock_gl,
+    mock_repligit_ops,
+):
+    """Config should only be refreshed when a default branch push touches the config file."""
+
+    mock_push_event.data["ref"] = ref
+    mock_push_event.data["commits"] = [
+        {"added": [], "modified": modified, "removed": []}
+    ]
+
+    await sync_branch(event=mock_push_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+
+    mock_repligit_ops["get_repo_config"].assert_awaited_once_with(
+        mock_gh, "owner/repo", refresh=expected_refresh
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "ref,fetched,commit_msg,webhook_expected",
+    [
+        # config was (re)fetched on a default branch push
+        ("refs/heads/main", True, "update app", True),
+        # cached config, no marker: nothing to do
+        ("refs/heads/main", False, "update app", False),
+        # manual trigger via commit message marker
+        ("refs/heads/main", False, "empty commit [hubcast config]", True),
+        # never set webhooks from non-default branches
+        ("refs/heads/feature", True, "update app", False),
+    ],
+)
+async def test_sync_branch_webhook_gating(
+    ref,
+    fetched,
+    commit_msg,
+    webhook_expected,
+    mock_push_event,
+    mock_gh,
+    mock_gl,
+    mock_repligit_ops,
+):
+    """Webhook should only be set on default branch pushes with a config fetch or marker."""
+
+    mock_push_event.data["ref"] = ref
+    mock_push_event.data["head_commit"]["message"] = commit_msg
+    config, _ = mock_repligit_ops["get_repo_config"].return_value
+    mock_repligit_ops["get_repo_config"].return_value = (config, fetched)
+
+    await sync_branch(event=mock_push_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+
+    if webhook_expected:
+        mock_gl.set_webhook.assert_awaited_once()
+    else:
+        mock_gl.set_webhook.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_branch_webhook_permission_denied(
+    mock_push_event, mock_gh, mock_gl, mock_repligit_ops
+):
+    """A non-maintainer pushing config changes should get a failed check explaining the fix."""
+
+    mock_gl.set_webhook.side_effect = WebhookPermissionError("not a maintainer")
+
+    await sync_branch(event=mock_push_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+
+    mock_gh.set_check_status.assert_awaited_once_with(
+        "sha-123",
+        ERROR_CHECK_NAME,
+        "failure",
+        title=WEBHOOK_PERMISSION_DENIED_TITLE,
+        summary=WEBHOOK_PERMISSION_DENIED_SUMMARY,
+    )
+    # the sync should not proceed
+    mock_repligit_ops["send_pack"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_branch_webhook_internal_error(
+    mock_push_event, mock_gh, mock_gl, mock_repligit_ops
+):
+    """A broken hubcast credential should be reported as an internal error."""
+
+    mock_gl.set_webhook.side_effect = HubcastError("GitLab rejected hubcast's token")
+
+    await sync_branch(event=mock_push_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+
+    mock_gh.set_check_status.assert_awaited_once_with(
+        "sha-123",
+        ERROR_CHECK_NAME,
+        "failure",
+        title=INTERNAL_ERROR_TITLE,
+        summary=INTERNAL_ERROR_SUMMARY,
+    )
+    mock_repligit_ops["send_pack"].assert_not_called()
+
+
 # Tests for remove_branch
 
 
@@ -421,6 +569,29 @@ async def test_sync_pr_skip_draft(
     await sync_pr_event(event=mock_pr_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
 
     assert "Skipped PR sync - draft PR" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_sync_pr_skip_draft_without_message(
+    mock_pr_event, mock_gh, mock_gl, mock_repligit_ops, caplog
+):
+    """Draft PR skips should not set a check status when sync_drafts_msg is False."""
+
+    mock_pr_event.data["pull_request"]["draft"] = True
+    mock_repligit_ops["get_repo_config"].return_value = (
+        Mock(
+            sync_drafts=False,
+            sync_drafts_msg=False,
+            dest_org="owner",
+            dest_name="repo",
+        ),
+        True,
+    )
+
+    await sync_pr_event(event=mock_pr_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+
+    assert "Skipped PR sync - draft PR" in caplog.text
+    mock_gh.set_check_status.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -547,6 +718,157 @@ async def test_sync_pr_skips_mr_when_already_exists(
     mock_gl.create_mr.assert_not_called()
 
 
+# Shared error-handling tests for sync_branch and sync_pr_event
+
+
+class SyncCase(NamedTuple):
+    """A sync handler plus the event fixture and expectations its error tests share."""
+
+    handler: Callable
+    event_fixture: str
+    sha: str
+    success_log: str
+
+
+sync_cases = pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            SyncCase(sync_branch, "mock_push_event", "sha-123", "Synced branch"),
+            id="sync_branch",
+        ),
+        pytest.param(
+            SyncCase(sync_pr_event, "mock_pr_event", "pr-sha-123", "Synced PR"),
+            id="sync_pr",
+        ),
+    ],
+)
+
+
+@pytest.mark.asyncio
+@sync_cases
+async def test_sync_config_error_sets_error_check(
+    case, request, mock_gh, mock_gl, mock_repligit_ops
+):
+    """An invalid repo config should be reported as a failed hubcast-error check."""
+
+    event = request.getfixturevalue(case.event_fixture)
+    mock_repligit_ops["get_repo_config"].side_effect = repo_config_error()
+
+    await case.handler(event=event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+
+    mock_gh.set_check_status.assert_awaited_once_with(
+        case.sha,
+        ERROR_CHECK_NAME,
+        "failure",
+        title="config title",
+        summary="config summary",
+    )
+    mock_repligit_ops["send_pack"].assert_not_called()
+
+
+@pytest.mark.asyncio
+@sync_cases
+@pytest.mark.parametrize(
+    "failing_op,error,expected_title,expected_summary",
+    [
+        (
+            "ls_remote",
+            permission_error(401),
+            PERMISSION_DENIED_TITLE,
+            PERMISSION_DENIED_SUMMARY,
+        ),
+        (
+            "ls_remote",
+            permission_error(403),
+            PERMISSION_DENIED_TITLE,
+            PERMISSION_DENIED_SUMMARY,
+        ),
+        (
+            "send_pack",
+            permission_error(403),
+            PERMISSION_DENIED_TITLE,
+            PERMISSION_DENIED_SUMMARY,
+        ),
+        (
+            "send_pack",
+            Exception(HOOK_DECLINED_MSG),
+            HOOK_DECLINED_TITLE,
+            HOOK_DECLINED_SUMMARY,
+        ),
+    ],
+    ids=["ls_remote-401", "ls_remote-403", "send_pack-403", "send_pack-hook-declined"],
+)
+async def test_sync_expected_error_fails_check(
+    case,
+    failing_op,
+    error,
+    expected_title,
+    expected_summary,
+    request,
+    mock_gh,
+    mock_gl,
+    mock_repligit_ops,
+    caplog,
+):
+    """Permission and hook-declined errors during sync should fail the pipeline check."""
+
+    event = request.getfixturevalue(case.event_fixture)
+    mock_repligit_ops[failing_op].side_effect = error
+
+    await case.handler(event=event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+
+    mock_gh.set_check_status.assert_awaited_once_with(
+        case.sha,
+        "hubcast",
+        "failure",
+        title=expected_title,
+        summary=expected_summary,
+    )
+    assert case.success_log not in caplog.text
+    if failing_op == "ls_remote":
+        assert PERMISSION_DENIED_SYNC_LOG_MSG in caplog.text
+        mock_repligit_ops["send_pack"].assert_not_called()
+
+
+@pytest.mark.asyncio
+@sync_cases
+async def test_sync_fetch_pack_failure_raises(
+    case, request, mock_gh, mock_gl, mock_repligit_ops
+):
+    """A missing packfile should raise instead of pushing nothing."""
+
+    event = request.getfixturevalue(case.event_fixture)
+    mock_repligit_ops["fetch_pack"].return_value = None
+
+    with pytest.raises(HubcastError, match="Failed to fetch packfile"):
+        await case.handler(event=event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+
+
+@pytest.mark.asyncio
+@sync_cases
+@pytest.mark.parametrize(
+    "failing_op,error",
+    [
+        ("ls_remote", permission_error(500)),
+        ("send_pack", permission_error(500)),
+        ("send_pack", Exception("connection reset")),
+    ],
+    ids=["ls_remote-http-500", "send_pack-http-500", "send_pack-generic"],
+)
+async def test_sync_other_error_raises(
+    case, failing_op, error, request, mock_gh, mock_gl, mock_repligit_ops
+):
+    """Unrecognized repligit errors during sync should propagate."""
+
+    event = request.getfixturevalue(case.event_fixture)
+    mock_repligit_ops[failing_op].side_effect = error
+
+    with pytest.raises(type(error)):
+        await case.handler(event=event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+    mock_gh.set_check_status.assert_not_called()
+
+
 # Tests for remove_pr
 
 
@@ -619,6 +941,110 @@ async def test_remove_pr_deleted(
     )
 
     assert "Deleted PR branch" in caplog.text
+
+
+# Shared error-handling tests for remove_branch and remove_pr
+
+
+class RemoveCase(NamedTuple):
+    """A removal handler plus the event fixture and expectations its error tests share."""
+
+    handler: Callable
+    event_fixture: str
+    ref: str
+    success_log: str
+
+
+remove_cases = pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            RemoveCase(
+                remove_branch,
+                "mock_delete_event",
+                "refs/heads/feature-branch",
+                "Deleted branch",
+            ),
+            id="remove_branch",
+        ),
+        pytest.param(
+            RemoveCase(
+                remove_pr,
+                "mock_pr_closed_event",
+                "refs/heads/pr-123",
+                "Deleted PR branch",
+            ),
+            id="remove_pr",
+        ),
+    ],
+)
+
+
+@pytest.mark.asyncio
+@remove_cases
+async def test_remove_ls_remote_permission_denied(
+    case, request, mock_gh, mock_gl, mock_repligit_ops, caplog
+):
+    """Permission errors on deletion should be logged; there is no sha to attach a check to."""
+
+    event = request.getfixturevalue(case.event_fixture)
+    mock_repligit_ops["ls_remote"].side_effect = permission_error()
+
+    await case.handler(event=event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+
+    assert PERMISSION_DENIED_DELETE_LOG_MSG in caplog.text
+    mock_gh.set_check_status.assert_not_called()
+    mock_repligit_ops["send_pack"].assert_not_called()
+
+
+@pytest.mark.asyncio
+@remove_cases
+@pytest.mark.parametrize(
+    "error,expected_log",
+    [
+        (permission_error(), PERMISSION_DENIED_DELETE_LOG_MSG),
+        (Exception(HOOK_DECLINED_MSG), HOOK_DECLINED_MSG),
+    ],
+    ids=["permission-denied", "hook-declined"],
+)
+async def test_remove_send_pack_swallowed_errors(
+    case, error, expected_log, request, mock_gh, mock_gl, mock_repligit_ops, caplog
+):
+    """Expected send_pack failures on deletion should be logged and not propagate."""
+
+    event = request.getfixturevalue(case.event_fixture)
+    mock_repligit_ops["ls_remote"].return_value = {case.ref: "dest-sha-123"}
+    mock_repligit_ops["send_pack"].side_effect = error
+
+    await case.handler(event=event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+
+    assert expected_log in caplog.text
+    assert case.success_log not in caplog.text
+    mock_gh.set_check_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+@remove_cases
+@pytest.mark.parametrize(
+    "failing_op,error",
+    [
+        ("ls_remote", permission_error(500)),
+        ("send_pack", permission_error(500)),
+        ("send_pack", Exception("connection reset")),
+    ],
+    ids=["ls_remote-http-500", "send_pack-http-500", "send_pack-generic"],
+)
+async def test_remove_other_error_raises(
+    case, failing_op, error, request, mock_gh, mock_gl, mock_repligit_ops
+):
+    """Unrecognized errors during deletion should propagate."""
+
+    event = request.getfixturevalue(case.event_fixture)
+    mock_repligit_ops["ls_remote"].return_value = {case.ref: "dest-sha-123"}
+    mock_repligit_ops[failing_op].side_effect = error
+
+    with pytest.raises(type(error)):
+        await case.handler(event=event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
 
 
 # Tests for respond_comment
@@ -856,6 +1282,132 @@ async def test_respond_comment_restart_jobs_variations(
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error,expected_response,expected_log",
+    [
+        (
+            BadRequest(HTTPStatus(403), "forbidden"),
+            PERMISSION_DENIED_SUMMARY,
+            "Pipeline failed to start - insufficient permissions",
+        ),
+        (
+            BadRequest(HTTPStatus(403), DEACTIVATED_ACCOUNT_MARKER),
+            DEACTIVATED_ACCOUNT_MSG,
+            "Pipeline failed to start - insufficient permissions",
+        ),
+        (
+            BadRequest(HTTPStatus(400), "invalid CI config"),
+            PIPELINE_FAILED_MSG,
+            "Pipeline failed to start",
+        ),
+    ],
+)
+async def test_respond_comment_run_pipeline_errors(
+    error,
+    expected_response,
+    expected_log,
+    mock_comment_event,
+    mock_gh,
+    mock_gl,
+    mock_repligit_ops,
+    mock_pr_data_for_comment,
+    caplog,
+):
+    """Pipeline start failures should be explained to the user in a comment."""
+
+    mock_comment_event.data["comment"]["body"] = "@hubcast-bot run pipeline"
+    mock_gh.get_pr = AsyncMock(return_value=mock_pr_data_for_comment)
+    mock_gl.run_pipeline = AsyncMock(side_effect=error)
+
+    await respond_comment(
+        event=mock_comment_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
+    )
+
+    assert expected_log in caplog.text
+    mock_gh.post_comment.assert_awaited_once()
+    _, response = mock_gh.post_comment.await_args.args
+    assert expected_response in response
+    mock_gh.react_to_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_respond_comment_run_pipeline_other_error_raises(
+    mock_comment_event, mock_gh, mock_gl, mock_repligit_ops, mock_pr_data_for_comment
+):
+    """Unrecognized pipeline start failures should propagate."""
+
+    mock_comment_event.data["comment"]["body"] = "@hubcast-bot run pipeline"
+    mock_gh.get_pr = AsyncMock(return_value=mock_pr_data_for_comment)
+    mock_gl.run_pipeline = AsyncMock(side_effect=BadRequest(HTTPStatus(500), "oops"))
+
+    with pytest.raises(BadRequest):
+        await respond_comment(
+            event=mock_comment_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failing_call,expected_log",
+    [
+        ("get_latest_pipeline", "Pipeline ID fetch failed - insufficient permissions"),
+        ("retry_pipeline_jobs", "Jobs restart failed - insufficient permissions"),
+    ],
+)
+async def test_respond_comment_restart_jobs_permission_denied(
+    failing_call,
+    expected_log,
+    mock_comment_event,
+    mock_gh,
+    mock_gl,
+    mock_repligit_ops,
+    mock_pr_data_for_comment,
+    caplog,
+):
+    """Permission errors restarting jobs should be explained to the user in a comment."""
+
+    mock_comment_event.data["comment"]["body"] = "@hubcast-bot restart failed"
+    mock_gh.get_pr = AsyncMock(return_value=mock_pr_data_for_comment)
+    mock_gl.get_latest_pipeline = AsyncMock(return_value=789)
+    getattr(mock_gl, failing_call).side_effect = BadRequest(
+        HTTPStatus(403), "forbidden"
+    )
+
+    await respond_comment(
+        event=mock_comment_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
+    )
+
+    assert expected_log in caplog.text
+    mock_gh.post_comment.assert_awaited_once()
+    _, response = mock_gh.post_comment.await_args.args
+    assert PERMISSION_DENIED_SUMMARY in response
+    mock_gh.react_to_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failing_call", ["get_latest_pipeline", "retry_pipeline_jobs"])
+async def test_respond_comment_restart_jobs_other_error_raises(
+    failing_call,
+    mock_comment_event,
+    mock_gh,
+    mock_gl,
+    mock_repligit_ops,
+    mock_pr_data_for_comment,
+):
+    """Unrecognized errors restarting jobs should propagate."""
+
+    mock_comment_event.data["comment"]["body"] = "@hubcast-bot restart failed"
+    mock_gh.get_pr = AsyncMock(return_value=mock_pr_data_for_comment)
+    mock_gl.get_latest_pipeline = AsyncMock(return_value=789)
+    getattr(mock_gl, failing_call).side_effect = BadRequest(HTTPStatus(500), "oops")
+
+    with pytest.raises(BadRequest):
+        await respond_comment(
+            event=mock_comment_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
+        )
+
+
 # Tests for rerun_check
 
 
@@ -889,3 +1441,89 @@ async def test_check_rerun_requested(
     )
 
     assert "Rerun check requested for branch" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_rerun_check_config_error_sets_error_check(
+    mock_check_run_event, mock_gh, mock_gl, mock_repligit_ops
+):
+    """An invalid repo config should be reported as a failed hubcast-error check."""
+
+    mock_gh.get_branch.return_value = {"commit": {"sha": "check-run-sha-123"}}
+    mock_repligit_ops["get_repo_config"].side_effect = repo_config_error()
+
+    await rerun_check(
+        event=mock_check_run_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
+    )
+
+    mock_gh.set_check_status.assert_awaited_once_with(
+        "check-run-sha-123",
+        ERROR_CHECK_NAME,
+        "failure",
+        title="config title",
+        summary="config summary",
+    )
+    mock_gl.run_pipeline.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error,expected_title,expected_summary",
+    [
+        (
+            BadRequest(HTTPStatus(403), "forbidden"),
+            PERMISSION_DENIED_TITLE,
+            PERMISSION_DENIED_SUMMARY,
+        ),
+        (
+            BadRequest(HTTPStatus(403), DEACTIVATED_ACCOUNT_MARKER),
+            DEACTIVATED_ACCOUNT_MSG,
+            "",
+        ),
+        (
+            BadRequest(HTTPStatus(400), "invalid CI config"),
+            PIPELINE_FAILED_MSG,
+            "invalid CI config",
+        ),
+    ],
+)
+async def test_rerun_check_pipeline_errors(
+    error,
+    expected_title,
+    expected_summary,
+    mock_check_run_event,
+    mock_gh,
+    mock_gl,
+    mock_repligit_ops,
+):
+    """Pipeline start failures during a check rerun should fail the check with details."""
+
+    mock_gh.get_branch.return_value = {"commit": {"sha": "check-run-sha-123"}}
+    mock_gl.run_pipeline = AsyncMock(side_effect=error)
+
+    await rerun_check(
+        event=mock_check_run_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
+    )
+
+    mock_gh.set_check_status.assert_awaited_once_with(
+        "check-run-sha-123",
+        "hubcast",
+        "failure",
+        title=expected_title,
+        summary=expected_summary,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rerun_check_pipeline_other_error_raises(
+    mock_check_run_event, mock_gh, mock_gl, mock_repligit_ops
+):
+    """Unrecognized pipeline start failures should propagate."""
+
+    mock_gh.get_branch.return_value = {"commit": {"sha": "check-run-sha-123"}}
+    mock_gl.run_pipeline = AsyncMock(side_effect=BadRequest(HTTPStatus(500), "oops"))
+
+    with pytest.raises(BadRequest):
+        await rerun_check(
+            event=mock_check_run_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
+        )

--- a/tests/test_github_routes.py
+++ b/tests/test_github_routes.py
@@ -9,6 +9,7 @@ import pytest
 from aiohttp.client_exceptions import ClientResponseError
 from gidgethub import sansio
 from gidgetlab.exceptions import BadRequest
+from repligit.exceptions import RefUpdateRejected
 
 from hubcast.exceptions import HubcastError, RepoConfigError, WebhookPermissionError
 from hubcast.web.github.messages import (
@@ -792,7 +793,7 @@ async def test_sync_config_error_sets_error_check(
         ),
         (
             "send_pack",
-            Exception(HOOK_DECLINED_MSG),
+            RefUpdateRejected(HOOK_DECLINED_MSG),
             HOOK_DECLINED_TITLE,
             HOOK_DECLINED_SUMMARY,
         ),
@@ -829,6 +830,29 @@ async def test_sync_expected_error_fails_check(
     if failing_op == "ls_remote":
         assert PERMISSION_DENIED_SYNC_LOG_MSG in caplog.text
         mock_repligit_ops["send_pack"].assert_not_called()
+
+
+@pytest.mark.asyncio
+@sync_cases
+async def test_sync_ref_update_rejected_other_reason_reports_and_raises(
+    case, request, mock_gh, mock_gl, mock_repligit_ops
+):
+    """A RefUpdateRejected reason other than the hook-declined message should still
+    fail the check for user visibility, but raise so Hubcast admins can debug."""
+
+    event = request.getfixturevalue(case.event_fixture)
+    mock_repligit_ops["send_pack"].side_effect = RefUpdateRejected("non-fast-forward")
+
+    with pytest.raises(RefUpdateRejected):
+        await case.handler(event=event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+
+    mock_gh.set_check_status.assert_awaited_once_with(
+        case.sha,
+        "hubcast",
+        "failure",
+        title=INTERNAL_ERROR_TITLE,
+        summary=INTERNAL_ERROR_SUMMARY,
+    )
 
 
 @pytest.mark.asyncio
@@ -1003,7 +1027,7 @@ async def test_remove_ls_remote_permission_denied(
     "error,expected_log",
     [
         (permission_error(), PERMISSION_DENIED_DELETE_LOG_MSG),
-        (Exception(HOOK_DECLINED_MSG), HOOK_DECLINED_MSG),
+        (RefUpdateRejected(HOOK_DECLINED_MSG), HOOK_DECLINED_MSG),
     ],
     ids=["permission-denied", "hook-declined"],
 )
@@ -1031,8 +1055,14 @@ async def test_remove_send_pack_swallowed_errors(
         ("ls_remote", permission_error(500)),
         ("send_pack", permission_error(500)),
         ("send_pack", Exception("connection reset")),
+        ("send_pack", RefUpdateRejected("non-fast-forward")),
     ],
-    ids=["ls_remote-http-500", "send_pack-http-500", "send_pack-generic"],
+    ids=[
+        "ls_remote-http-500",
+        "send_pack-http-500",
+        "send_pack-generic",
+        "send_pack-ref-rejected-other-reason",
+    ],
 )
 async def test_remove_other_error_raises(
     case, failing_op, error, request, mock_gh, mock_gl, mock_repligit_ops
@@ -1316,7 +1346,7 @@ async def test_respond_comment_run_pipeline_errors(
 ):
     """Pipeline start failures should be explained to the user in a comment."""
 
-    mock_comment_event.data["comment"]["body"] = "@hubcast-bot run pipeline"
+    mock_comment_event.data["comment"]["body"] = "@hubcast-bot rerun pipeline"
     mock_gh.get_pr = AsyncMock(return_value=mock_pr_data_for_comment)
     mock_gl.run_pipeline = AsyncMock(side_effect=error)
 
@@ -1337,7 +1367,7 @@ async def test_respond_comment_run_pipeline_other_error_raises(
 ):
     """Unrecognized pipeline start failures should propagate."""
 
-    mock_comment_event.data["comment"]["body"] = "@hubcast-bot run pipeline"
+    mock_comment_event.data["comment"]["body"] = "@hubcast-bot rerun pipeline"
     mock_gh.get_pr = AsyncMock(return_value=mock_pr_data_for_comment)
     mock_gl.run_pipeline = AsyncMock(side_effect=BadRequest(HTTPStatus(500), "oops"))
 

--- a/tests/test_github_routes.py
+++ b/tests/test_github_routes.py
@@ -205,6 +205,7 @@ def mock_gh():
     gh.post_comment = AsyncMock()
     gh.react_to_comment = AsyncMock()
     gh.auth.authenticate_installation = AsyncMock(return_value="gh-token-123")
+    gh.repo_config_path = ".github/hubcast.yml"
     return gh
 
 

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -62,6 +62,49 @@ def test_create_config_full():
     assert config.sync_drafts_msg is False
 
 
+def test_check_types_defaults_to_pipeline():
+    """Should default check_types to just 'pipeline'."""
+
+    config = RepoConfig.model_validate(
+        {"Repo": {"dest_org": "owner", "dest_name": "repo"}}
+    )
+
+    assert config.check_types == ["pipeline"]
+
+
+def test_check_types_always_includes_pipeline():
+    """Should force-enable the 'pipeline' check even if omitted by the user."""
+
+    config = RepoConfig.model_validate(
+        {
+            "Repo": {
+                "dest_org": "owner",
+                "dest_name": "repo",
+                "check_types": ["jobs"],
+            }
+        }
+    )
+
+    assert "pipeline" in config.check_types
+    assert "jobs" in config.check_types
+
+
+def test_check_types_no_duplicate_pipeline():
+    """Should not duplicate 'pipeline' if the user already included it."""
+
+    config = RepoConfig.model_validate(
+        {
+            "Repo": {
+                "dest_org": "owner",
+                "dest_name": "repo",
+                "check_types": ["pipeline", "jobs"],
+            }
+        }
+    )
+
+    assert config.check_types == ["pipeline", "jobs"]
+
+
 def test_validator_with_non_dict():
     """Should handle non-dict input by passing through to other validators."""
     # The validator should pass through non-dict data

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -2,9 +2,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from hubcast.exceptions import HubcastError
+from hubcast.exceptions import HubcastError, RepoConfigError
 from hubcast.repos.config import RepoConfig
-from hubcast.web.github.utils import config_cache, get_repo_config
+from hubcast.web.github.messages import CONFIG_INVALID_SUMMARY, CONFIG_INVALID_TITLE
+from hubcast.web.github.utils import (
+    changed_files_from_push,
+    config_cache,
+    get_repo_config,
+)
 
 
 ### FIXTURES
@@ -163,8 +168,14 @@ async def test_get_repo_config_invalid_yaml():
     gh.repo_owner = "owner"
     gh.repo_name = "repo"
 
-    with pytest.raises(HubcastError, match="Invalid YAML in repo config"):
+    with pytest.raises(
+        RepoConfigError, match="Invalid YAML in repo config"
+    ) as exc_info:
         await get_repo_config(gh, "owner/repo")
+
+    # route handlers report these to the user via a failed check
+    assert exc_info.value.title == CONFIG_INVALID_TITLE
+    assert exc_info.value.summary == CONFIG_INVALID_SUMMARY
 
 
 @pytest.mark.asyncio
@@ -176,10 +187,12 @@ async def test_get_repo_config_missing_repo_key():
     gh.repo_owner = "owner"
     gh.repo_name = "repo"
 
-    with pytest.raises(HubcastError, match="Invalid repo config") as exc_info:
+    with pytest.raises(RepoConfigError, match="Invalid repo config") as exc_info:
         await get_repo_config(gh, "owner/repo")
 
     assert "top-level 'Repo' section" in exc_info.value.context["error"]
+    assert exc_info.value.title == CONFIG_INVALID_TITLE
+    assert exc_info.value.summary == CONFIG_INVALID_SUMMARY
 
 
 @pytest.mark.asyncio
@@ -191,7 +204,7 @@ async def test_get_repo_config_missing_required_fields():
     gh.repo_owner = "owner"
     gh.repo_name = "repo"
 
-    with pytest.raises(HubcastError, match="Invalid repo config") as exc_info:
+    with pytest.raises(RepoConfigError, match="Invalid repo config") as exc_info:
         await get_repo_config(gh, "owner/repo")
 
     assert "Field required" in exc_info.value.context["error"]
@@ -223,3 +236,34 @@ async def test_get_repo_config_not_found_from_cache():
 
     # should only call GH once since second call used cache
     gh.get_repo_config.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        pytest.param(
+            {
+                "commits": [
+                    {"added": ["new.py"], "modified": ["src/app.py"], "removed": []},
+                    {
+                        "added": [],
+                        "modified": ["docs/readme.md"],
+                        "removed": ["old.py"],
+                    },
+                ]
+            },
+            {"new.py", "src/app.py", "docs/readme.md", "old.py"},
+            id="collects_all_commits",
+        ),
+        pytest.param(
+            {"commits": [{"added": ["new.py"]}]},
+            {"new.py"},
+            id="tolerates_missing_keys",
+        ),
+        pytest.param({"commits": []}, set(), id="empty"),
+    ],
+)
+def test_changed_files_from_push(payload, expected):
+    """Should collect changed paths across commits, tolerating missing keys."""
+
+    assert changed_files_from_push(payload) == expected

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -133,8 +133,10 @@ async def test_get_repo_config_missing_repo_key():
     gh.repo_owner = "owner"
     gh.repo_name = "repo"
 
-    with pytest.raises(HubcastError, match="top-level 'Repo' section"):
+    with pytest.raises(HubcastError, match="Invalid repo config") as exc_info:
         await get_repo_config(gh, "owner/repo")
+
+    assert "top-level 'Repo' section" in exc_info.value.context["error"]
 
 
 @pytest.mark.asyncio
@@ -146,8 +148,10 @@ async def test_get_repo_config_missing_required_fields():
     gh.repo_owner = "owner"
     gh.repo_name = "repo"
 
-    with pytest.raises(HubcastError, match="Field required"):
+    with pytest.raises(HubcastError, match="Invalid repo config") as exc_info:
         await get_repo_config(gh, "owner/repo")
+
+    assert "Field required" in exc_info.value.context["error"]
 
 
 @pytest.mark.asyncio
@@ -171,7 +175,7 @@ async def test_get_repo_config_not_found_from_cache():
         await get_repo_config(gh, "owner/repo")
 
     # second call should discover cache has None
-    with pytest.raises(HubcastError, match="Config file not found"):
+    with pytest.raises(HubcastError, match="Repo config file not found"):
         await get_repo_config(gh, "owner/repo")
 
     # should only call GH once since second call used cache


### PR DESCRIPTION
This PR adds support for sending messages back to users if their intended action fails due to insufficient permissions.

Any requests to Gitlab can fail if the user account we're impersonating is not set up properly. 

1. with the `guest` role, the user can't read the repo
2. with the `reporter` role, the user can't write to the repo
3. with the `developer` role, the user can't read or write repo webhooks

If we hit (1) or (2) during a sync action, Hubcast will set a status to the commit notifying the user of the issue and pointing to the permissions requirements in the docs.

In the case of deletions, we have no way to set a GitHub check status so the event will be logged and available to admins.

The way we go about catching exceptions is ugly, but modularization is limited by the fact that most cases need unique handling, other than actions like syncing/deleting refs (which should really be consolidated like in #240). Please let me know if you have ideas about making this all more readable.

Handling webhook setting:
- we now check if hubcast configuration files have been added/edited/deleted in the push event to the default branch
- if the webhook set fails, we set a check with an error message saying that a maintainer needs to push an update to the config or an empty commit with the message `[hubcast config`]
--- 

TODO
- [x] once this is in a polished state, add tests
- [x] we'll need to cut a repligit release to handle the rejected push exceptions

closes #355 