### PR TITLE
update type hints

### DIFF
--- a/src/hubcast/account_map/abc.py
+++ b/src/hubcast/account_map/abc.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Union
 
 
 class AccountMap(ABC):
@@ -8,7 +7,7 @@ class AccountMap(ABC):
     """
 
     @abstractmethod
-    def __call__(self, github_user: str) -> Union[str, None]:
+    def __call__(self, github_user: str) -> str | None:
         """
         Return the coorisponding gitlab_user for a given github_user if
         one exists.

--- a/src/hubcast/account_map/file.py
+++ b/src/hubcast/account_map/file.py
@@ -1,5 +1,3 @@
-from typing import Dict, Union
-
 import yaml
 
 from .abc import AccountMap
@@ -24,7 +22,7 @@ class FileMap(AccountMap):
     """
 
     path: str
-    users: Dict[str, str]
+    users: dict[str, str]
 
     def __init__(self, path: str):
         """
@@ -42,7 +40,7 @@ class FileMap(AccountMap):
         except yaml.YAMLError:
             raise FileMapError(f"Failed to parse file map. path={path}")
 
-    def __call__(self, github_user: str) -> Union[str, None]:
+    def __call__(self, github_user: str) -> str | None:
         """
         Return the gitlab_user for a github_user if one exists.
         """

--- a/src/hubcast/account_map/ldap.py
+++ b/src/hubcast/account_map/ldap.py
@@ -1,6 +1,6 @@
 import logging
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Optional, Union
 
 import ldap
 import ldap.sasl
@@ -14,7 +14,7 @@ ldap.set_option(ldap.OPT_NETWORK_TIMEOUT, 5)
 
 
 @contextmanager
-def ldap_connection(uri: str):
+def ldap_connection(uri: str) -> Generator[ldap.ldapobject.LDAPObject, None, None]:
     """
     Manages context for python-ldap connections.
     Yields the connection and unbinds on exit.
@@ -47,9 +47,9 @@ class LDAPMap(AccountMap):
         the attribute to select as output, eg: uid
     search_scope : int
         one of ldap.SCOPE_BASE, ldap.SCOPE_ONELEVEL, ldap.SCOPE_SUBTREE
-    bind_dn : Optional[str]
+    bind_dn : str | None
         optional DN for simple bind (falls back to GSSAPI if None)
-    bind_password : Optional[str]
+    bind_password : str | None
         password for simple bind (ignored when using GSSAPI)
     """
 
@@ -60,8 +60,8 @@ class LDAPMap(AccountMap):
         input_attr: str,
         output_attr: str,
         search_scope: int,
-        bind_dn: Optional[str] = None,
-        bind_password: Optional[str] = None,
+        bind_dn: str | None = None,
+        bind_password: str | None = None,
     ):
         self.uri = uri
         self.search_base = search_base
@@ -71,7 +71,7 @@ class LDAPMap(AccountMap):
         self.bind_dn = bind_dn
         self.bind_password = bind_password
 
-    def __call__(self, input_val: str) -> Union[str, None]:
+    def __call__(self, input_val: str) -> str | None:
         """
         searches the LDAP endpoint for input_val within the search_base and returns
         the value of output_attr.

--- a/src/hubcast/clients/github/auth.py
+++ b/src/hubcast/clients/github/auth.py
@@ -1,5 +1,4 @@
 import time
-from typing import Tuple
 
 import aiohttp
 import gidgethub.apps as gha
@@ -27,12 +26,12 @@ class GitHubAuthenticator:
         A string of the numeric GitHub App's ID.
     """
 
-    def __init__(self, requester: str, private_key: str, app_id: str) -> None:
+    def __init__(self, requester: str, private_key: str, app_id: str):
         self.requester = requester
         self.private_key = private_key
         self.app_id = app_id
         self._tokens = TokenCache()
-        self._id_dict = {}
+        self._id_dict: dict[tuple[str, str], str] = {}
 
     async def get_installation_id(self, owner: str, repo: str) -> str:
         if (owner, repo) not in self._id_dict:
@@ -56,7 +55,7 @@ class GitHubAuthenticator:
 
         installation_id = await self.get_installation_id(owner, repo)
 
-        async def renew_installation_token():
+        async def renew_installation_token() -> tuple[int, str]:
             async with aiohttp.ClientSession() as session:
                 gh = gh_aiohttp.GitHubAPI(session, self.requester)
 
@@ -86,7 +85,7 @@ class GitHubAuthenticator:
     async def get_jwt(self) -> str:
         """Get a JWT from cache, creating a new one if necessary."""
 
-        async def renew_jwt() -> Tuple[float, str]:
+        async def renew_jwt() -> tuple[float, str]:
             # GitHub requires that you create a JWT signed with the application's
             # private key. You need the app id and the private key, and you can
             # use this gidgethub method to create the JWT.

--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 from urllib.parse import urlparse
 
 import aiohttp
@@ -22,19 +23,26 @@ GH_REACTIONS = {
 
 
 class GitHubClientFactory:
-    def __init__(self, app_id, privkey, requester, bot_caller):
+    def __init__(self, app_id: str, privkey: str, requester: str, bot_caller: str):
         self.requester = requester
         self.auth = GitHubAuthenticator(requester, privkey, app_id)
         self.bot_caller = bot_caller
 
-    def create_client(self, repo_owner, repo_name):
+    def create_client(self, repo_owner: str, repo_name: str) -> "GitHubClient":
         return GitHubClient(
             self.auth, self.requester, repo_owner, repo_name, self.bot_caller
         )
 
 
 class GitHubClient:
-    def __init__(self, auth, requester, repo_owner, repo_name, bot_caller):
+    def __init__(
+        self,
+        auth: GitHubAuthenticator,
+        requester: str,
+        repo_owner: str,
+        repo_name: str,
+        bot_caller: str,
+    ):
         self.auth = auth
         self.requester = requester
         self.repo_owner = repo_owner
@@ -46,9 +54,9 @@ class GitHubClient:
         ref: str,
         check_name: str,
         status: str,
-        details_url: str = None,
-        message: str = None,
-    ):
+        details_url: str | None = None,
+        message: str | None = None,
+    ) -> None:
         """
         Set the status of a GitHub check.
 
@@ -120,7 +128,7 @@ class GitHubClient:
                 url = f"/repos/{self.repo_owner}/{self.repo_name}/check-runs/{existing_check['id']}"
                 await gh.patch(url, data=payload)
 
-    async def get_repo_config(self):
+    async def get_repo_config(self) -> str:
         gh_token = await self.auth.authenticate_installation(
             self.repo_owner, self.repo_name
         )
@@ -144,7 +152,7 @@ class GitHubClient:
                     )
                 raise
 
-    async def get_pr(self, id):
+    async def get_pr(self, id: int) -> dict[str, Any]:
         """Return individual PR data."""
         gh_token = await self.auth.authenticate_installation(
             self.repo_owner, self.repo_name
@@ -156,7 +164,7 @@ class GitHubClient:
             url = f"/repos/{self.repo_owner}/{self.repo_name}/pulls/{id}"
             return await gh.getitem(url)
 
-    async def get_prs(self, branch=None):
+    async def get_prs(self, branch: str | None = None) -> list[int] | None:
         """Returns a list of all open PR numbers; can be filtered by internal branches."""
 
         gh_token = await self.auth.authenticate_installation(
@@ -174,8 +182,9 @@ class GitHubClient:
                 url = f"{url}?head={self.repo_owner}:{branch}"
                 prs_res = await gh.getitem(url)
                 return [pr["number"] for pr in prs_res]
+        return None
 
-    async def post_comment(self, issue_number: int, body: str):
+    async def post_comment(self, issue_number: int, body: str) -> None:
         payload = {"body": body}
 
         gh_token = await self.auth.authenticate_installation(
@@ -188,7 +197,7 @@ class GitHubClient:
             url = f"/repos/{self.repo_owner}/{self.repo_name}/issues/{issue_number}/comments"
             await gh.post(url, data=payload)
 
-    async def react_to_comment(self, node_id: str, reaction: str):
+    async def react_to_comment(self, node_id: str, reaction: str) -> None:
         """
         Add an emoji reaction to a GitHub issue comment or PR review.
         See `GH_REACTIONS.keys()` for a list of emoji options.
@@ -218,7 +227,7 @@ class GitHubClient:
                 mutation, subjectId=node_id, content=GH_REACTIONS[reaction]
             )
 
-    async def get_branch(self, name: str):
+    async def get_branch(self, name: str) -> dict[str, Any]:
         """Return individual branch data."""
 
         gh_token = await self.auth.authenticate_installation(

--- a/src/hubcast/clients/gitlab/auth.py
+++ b/src/hubcast/clients/gitlab/auth.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from typing import Tuple
 
 import aiohttp
 import gidgetlab.aiohttp
@@ -35,7 +34,7 @@ class GitLabAuthenticator:
     async def authenticate_user(
         self,
         username: str,
-        scopes: list = GL_SCOPES,
+        scopes: list[str] = GL_SCOPES,
         expire_days: int = 1,
     ) -> str:
         """
@@ -53,7 +52,7 @@ class GitLabAuthenticator:
             the number of days after which the token will expire on the gitlab server
         """
 
-        async def renew_impersonation_token():
+        async def renew_impersonation_token() -> tuple[int, str]:
             # the tokens API requires user IDs, but hubcast's account mapping returns usernames
             user_id = await self._get_user_id(username)
 
@@ -102,7 +101,7 @@ class GitLabAuthenticator:
             return res[0]["id"]
 
     @staticmethod
-    def _date_after_days(days: int) -> Tuple[str, int]:
+    def _date_after_days(days: int) -> tuple[str, int]:
         """Returns UTC date string in YYYY-MM-DD format and midnight UTC timestamp."""
         dt = (datetime.now(timezone.utc) + timedelta(days=days)).replace(
             hour=0, minute=0, second=0, microsecond=0

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -1,6 +1,5 @@
 import logging
 import urllib.parse
-from typing import Dict
 
 import aiohttp
 import gidgetlab
@@ -33,7 +32,7 @@ class GitLabClientFactory:
         self.callback_url = callback_url
         self.webhook_secret = webhook_secret
 
-    def create_client(self, user: str):
+    def create_client(self, user: str) -> "GitLabClient":
         """creates a GitLabClient for a specific user"""
         return GitLabClient(
             self.auth,
@@ -48,7 +47,7 @@ class GitLabClientFactory:
 class GitLabClient:
     def __init__(
         self,
-        auth: GitLabAuthenticator,
+        auth: GitLabAuthenticator | GitLabSingleUserAuthenticator,
         requester: str,
         instance_url: str,
         callback_url: str,
@@ -62,7 +61,7 @@ class GitLabClient:
         self.webhook_secret = webhook_secret
         self.user = user
 
-    async def set_webhook(self, gl_fullname: str, data: Dict):
+    async def set_webhook(self, gl_fullname: str, data: dict[str, str]) -> None:
         gl_token = await self.auth.authenticate_user(username=self.user)
 
         new_hook = {

--- a/src/hubcast/clients/utils.py
+++ b/src/hubcast/clients/utils.py
@@ -1,5 +1,5 @@
 import time
-from typing import Awaitable, Callable, Tuple
+from typing import Awaitable, Callable
 
 
 class TokenCache:
@@ -7,13 +7,13 @@ class TokenCache:
     Cache for web tokens with an expiration.
     """
 
-    def __init__(self) -> None:
-        self._tokens = {}
+    def __init__(self):
+        self._tokens: dict[str, tuple[float, str]] = {}
 
     async def get(
         self,
         name: str,
-        renew: Callable[[], Awaitable[Tuple[float, str]]],
+        renew: Callable[[], Awaitable[tuple[float, str]]],
         time_needed: int = 60,
     ) -> str:
         """
@@ -23,7 +23,7 @@ class TokenCache:
         ---------
         name: str
             An identifying name of a token to get from the cache.
-        renew: Callable[[], Awaitable[Tuple[float, str]]]
+        renew: Callable[[], Awaitable[tuple[float, str]]]
             A function to call in order to generate a new token if the cache
             is stale.
         time_needed: int

--- a/src/hubcast/config.py
+++ b/src/hubcast/config.py
@@ -50,7 +50,7 @@ class GitLabConfig:
         self.callback_url = env_get("HC_GL_CALLBACK_URL")
 
 
-def env_get(key: str, default=None, optional: bool = False):
+def env_get(key: str, default: str | None = None, optional: bool = False) -> str | None:
     """
     Retrieve environment variables.
 

--- a/src/hubcast/logging.py
+++ b/src/hubcast/logging.py
@@ -32,7 +32,7 @@ LOG_RECORD_BUILTIN_ATTRS = frozenset(
 
 
 class HubcastJSONFormatter(logging.Formatter):
-    def __init__(self, *, fmt_keys=None):
+    def __init__(self, *, fmt_keys: dict[str, str] | None = None) -> None:
         super().__init__()
         self.fmt_keys = fmt_keys or {}
 

--- a/src/hubcast/web/comments.py
+++ b/src/hubcast/web/comments.py
@@ -1,4 +1,4 @@
-def help_message(bot_caller: str):
+def help_message(bot_caller: str) -> str:
     return f"""
 You can interact with me in many ways!
 

--- a/src/hubcast/web/github/handler.py
+++ b/src/hubcast/web/github/handler.py
@@ -4,6 +4,10 @@ from aiohttp import web
 from aiojobs.aiohttp import spawn
 from gidgethub import sansio
 
+from hubcast.account_map.abc import AccountMap
+from hubcast.clients.github.client import GitHubClientFactory
+from hubcast.clients.gitlab.client import GitLabClientFactory
+
 from .routes import router
 
 log = logging.getLogger(__name__)
@@ -11,14 +15,18 @@ log = logging.getLogger(__name__)
 
 class GitHubHandler:
     def __init__(
-        self, webhook_secret, account_map, github_client_factory, gitlab_client_factory
+        self,
+        webhook_secret: str,
+        account_map: AccountMap,
+        github_client_factory: GitHubClientFactory,
+        gitlab_client_factory: GitLabClientFactory,
     ):
         self.webhook_secret = webhook_secret
         self.account_map = account_map
         self.gh = github_client_factory
         self.gl = gitlab_client_factory
 
-    async def handle(self, request):
+    async def handle(self, request: web.Request) -> web.Response:
         try:
             # read the GitHub webhook payload
             body = await request.read()

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -5,6 +5,8 @@ from typing import Any
 from gidgethub import routing, sansio
 from repligit.asyncio import fetch_pack, ls_remote, send_pack
 
+from hubcast.clients.github.client import GitHubClient
+from hubcast.clients.gitlab.client import GitLabClient
 from hubcast.web import comments
 from hubcast.web.github.utils import get_repo_config
 
@@ -40,7 +42,14 @@ router = GitHubRouter()
 # Push Events
 # -----------------------------------
 @router.register("push", deleted=False)
-async def sync_branch(event, gh, gl, gl_user, *arg, **kwargs):
+async def sync_branch(
+    event: sansio.Event,
+    gh: GitHubClient,
+    gl: GitLabClient,
+    gl_user: str,
+    *arg,
+    **kwargs,
+) -> None:
     """Sync the git branch referenced to GitLab."""
     src_repo_url = event.data["repository"]["clone_url"]
     src_fullname = event.data["repository"]["full_name"]
@@ -116,7 +125,14 @@ async def sync_branch(event, gh, gl, gl_user, *arg, **kwargs):
 
 
 @router.register("push", deleted=True)
-async def remove_branch(event, gh, gl, gl_user, *arg, **kwargs):
+async def remove_branch(
+    event: sansio.Event,
+    gh: GitHubClient,
+    gl: GitLabClient,
+    gl_user: str,
+    *arg,
+    **kwargs,
+) -> None:
     src_fullname = event.data["repository"]["full_name"]
     target_ref = event.data["ref"]
 
@@ -147,7 +163,14 @@ async def remove_branch(event, gh, gl, gl_user, *arg, **kwargs):
 # -----------------------------------
 
 
-async def sync_pr(pull_request, gh, gl, gl_user, src_repo_private, want_sha):
+async def sync_pr(
+    pull_request: dict[str, Any],
+    gh: GitHubClient,
+    gl: GitLabClient,
+    gl_user: str,
+    src_repo_private: bool,
+    want_sha: str,
+) -> None:
     """Sync the git fork/branch referenced in a PR to GitLab.
 
     This isn't technically an event handler, but is used a couple different ways in this file.
@@ -249,7 +272,14 @@ async def sync_pr(pull_request, gh, gl, gl_user, src_repo_private, want_sha):
 @router.register("pull_request", action="opened")
 @router.register("pull_request", action="reopened")
 @router.register("pull_request", action="synchronize")
-async def sync_pr_event(event, gh, gl, gl_user, *arg, **kwargs):
+async def sync_pr_event(
+    event: sansio.Event,
+    gh: GitHubClient,
+    gl: GitLabClient,
+    gl_user: str,
+    *arg,
+    **kwargs,
+) -> None:
     """Sync the git fork/branch referenced in a PR to GitLab."""
     pull_request = event.data["pull_request"]
     src_repo_private = pull_request["head"]["repo"]["private"]
@@ -263,7 +293,14 @@ async def sync_pr_event(event, gh, gl, gl_user, *arg, **kwargs):
 
 
 @router.register("pull_request", action="closed")
-async def remove_pr(event, gh, gl, gl_user, *arg, **kwargs):
+async def remove_pr(
+    event: sansio.Event,
+    gh: GitHubClient,
+    gl: GitLabClient,
+    gl_user: str,
+    *arg,
+    **kwargs,
+) -> None:
     pull_request = event.data["pull_request"]
     src_fullname = pull_request["head"]["repo"]["full_name"]
     base_fullname = pull_request["base"]["repo"]["full_name"]
@@ -304,7 +341,14 @@ async def remove_pr(event, gh, gl, gl_user, *arg, **kwargs):
 
 
 @router.register("pull_request_review", action="submitted")
-async def respond_pr_comment(event, gh, gl, gl_user, *arg, **kwargs):
+async def respond_pr_comment(
+    event: sansio.Event,
+    gh: GitHubClient,
+    gl: GitLabClient,
+    gl_user: str,
+    *arg,
+    **kwargs,
+) -> None:
     comment = event.data["review"]["body"]
 
     if re.search(f"{gh.bot_caller} approve", comment, re.IGNORECASE):
@@ -323,7 +367,14 @@ async def respond_pr_comment(event, gh, gl, gl_user, *arg, **kwargs):
 
 
 @router.register("issue_comment", action="created")
-async def respond_comment(event, gh, gl, gl_user, *arg, **kwargs):
+async def respond_comment(
+    event: sansio.Event,
+    gh: GitHubClient,
+    gl: GitLabClient,
+    gl_user: str,
+    *arg,
+    **kwargs,
+) -> None:
     # differentiate issue vs PR comment
     if "pull_request" not in event.data["issue"]:
         return
@@ -416,7 +467,14 @@ async def respond_comment(event, gh, gl, gl_user, *arg, **kwargs):
 
 
 @router.register("check_run", action="rerequested")
-async def rerun_check(event, gh, gl, gl_user, *arg, **kwargs):
+async def rerun_check(
+    event: sansio.Event,
+    gh: GitHubClient,
+    gl: GitLabClient,
+    gl_user: str,
+    *arg,
+    **kwargs,
+) -> None:
     """
     Handles a user re-running a check run for the latest commit in the branch.
     See https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=rerequested#check_run.

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -1,16 +1,16 @@
 import logging
-from typing import Dict
+from typing import Any
 
 import yaml
 
 from hubcast.clients.github import GitHubClient
 from hubcast.repos.config import RepoConfig
 
-config_cache = dict()
+config_cache: dict[str, RepoConfig] = {}
 log = logging.getLogger(__name__)
 
 
-def create_config(fullname: str, data: Dict) -> RepoConfig:
+def create_config(fullname: str, data: dict[str, Any]) -> RepoConfig:
     return RepoConfig(
         fullname=fullname,
         dest_org=data["Repo"]["owner"],
@@ -20,7 +20,9 @@ def create_config(fullname: str, data: Dict) -> RepoConfig:
     )
 
 
-async def get_repo_config(gh: GitHubClient, fullname: str, refresh: bool = False):
+async def get_repo_config(
+    gh: GitHubClient, fullname: str, refresh: bool = False
+) -> tuple[RepoConfig, bool]:
     fetched = False
     if fullname in config_cache and not refresh:
         config = config_cache[fullname]

--- a/src/hubcast/web/gitlab/handler.py
+++ b/src/hubcast/web/gitlab/handler.py
@@ -17,7 +17,7 @@ class GitLabHandler:
         self.webhook_secret = webhook_secret
         self.github_client_factory = github_client_factory
 
-    async def handle(self, request):
+    async def handle(self, request: web.Request) -> web.Response:
         try:
             # read the GitLab webhook payload
             body = await request.read()

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -3,6 +3,8 @@ from typing import Any
 
 from gidgetlab import routing, sansio
 
+from hubcast.clients.github.client import GitHubClient
+
 log = logging.getLogger(__name__)
 
 # https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks#about-check-suites
@@ -67,7 +69,9 @@ router = GitLabRouter()
 @router.register("Pipeline Hook", status="canceled")
 @router.register("Pipeline Hook", status="skipped")
 @router.register("Pipeline Hook", status="success")
-async def status_relay(event, gh, gh_check_name, *arg, **kwargs):
+async def status_relay(
+    event: sansio.Event, gh: GitHubClient, gh_check_name: str, *arg, **kwargs
+) -> None:
     """Relay status of a GitLab pipeline back to GitHub."""
     # get ref from event
     ref = event.data["object_attributes"]["sha"]


### PR DESCRIPTION
Replace old typing module imports (Dict, Tuple, Union, Optional) with built in generics (supporting Python 3.10+)

Add type annotations to functions missing them.