### PR TITLE
Make logging config file optional to fallback to default

### DIFF
--- a/src/hubcast/__main__.py
+++ b/src/hubcast/__main__.py
@@ -39,7 +39,8 @@ def main():
         log.error(exc)
         sys.exit(1)
 
-    if os.path.exists(conf.logging_config_path):
+    logging_config_path = conf.logging_config_path
+    if logging_config_path and os.path.exists(logging_config_path):
         try:
             with open(conf.logging_config_path) as f:
                 logging_config = json.load(f)

--- a/src/hubcast/config.py
+++ b/src/hubcast/config.py
@@ -11,7 +11,7 @@ class Config:
 
         self.account_map_type = env_get("HC_ACCOUNT_MAP_TYPE")
 
-        self.logging_config_path = env_get("HC_LOGGING_CONFIG_PATH")
+        self.logging_config_path = env_get("HC_LOGGING_CONFIG_PATH", optional=True)
 
         if self.account_map_type == "file":
             self.account_map_path = env_get("HC_ACCOUNT_MAP_PATH")


### PR DESCRIPTION
If a `logging_config_path` isn't defined we fallback to a basic config in `__main__.py`. However, we were previously enforcing a file be specified when parsing a config which meant someone couldn't leave the variable undefined to fallback to basic logging.

This PR makes the logging config path optional in the config parser.