### PR TITLE
Factor out logging setup from __main__() and optional conf path

### DIFF
--- a/src/hubcast/__main__.py
+++ b/src/hubcast/__main__.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import logging.config
-import os
 import sys
 from pathlib import Path
 

--- a/src/hubcast/__main__.py
+++ b/src/hubcast/__main__.py
@@ -3,6 +3,7 @@ import logging
 import logging.config
 import os
 import sys
+from pathlib import Path
 
 from aiohttp import web
 from aiojobs.aiohttp import setup
@@ -29,6 +30,35 @@ log = logging.getLogger(__name__)
 # Set requester for both GitHub and GitLab clients to
 # identify Hubcast via the user-agent header
 REQUESTER = "hubcast"
+
+
+def initialize_logging(conf: Config) -> None:
+    """Initialize logging based on configuration."""
+    if not conf.logging_config_path:
+        logging.basicConfig(level=logging.INFO)
+        return
+
+    config_path = Path(conf.logging_config_path)
+    if not config_path.exists():
+        log.error(
+            "Logging config file not found",
+            extra={"path": conf.logging_config_path},
+        )
+        sys.exit(1)
+
+    try:
+        logging_config = json.loads(config_path.read_text())
+        logging.config.dictConfig(logging_config)
+    except (
+        json.JSONDecodeError,
+        # calls to logging.config.dictConfig will raise the following exceptions (cf stdlib docs):
+        ValueError,
+        TypeError,
+        AttributeError,
+        ImportError,
+    ) as exc:
+        log.error(exc)
+        sys.exit(1)
 
 
 def initialize_account_map(conf: Config) -> AccountMap:
@@ -76,23 +106,7 @@ def main():
         log.error(exc)
         sys.exit(1)
 
-    if os.path.exists(conf.logging_config_path):
-        try:
-            with open(conf.logging_config_path) as f:
-                logging_config = json.load(f)
-            logging.config.dictConfig(logging_config)
-        except (
-            json.decoder.JSONDecodeError,
-            # calls to logging.config.dictConfig will raise the following exceptions (cf stdlib docs):
-            ValueError,
-            TypeError,
-            AttributeError,
-            ImportError,
-        ) as exc:
-            log.error(exc)
-            sys.exit(1)
-    else:
-        logging.basicConfig(level=logging.INFO)
+    initialize_logging(conf)
 
     account_map = initialize_account_map(conf)
 

--- a/src/hubcast/config.py
+++ b/src/hubcast/config.py
@@ -11,7 +11,7 @@ class Config:
 
         self.account_map_type = env_get("HC_ACCOUNT_MAP_TYPE")
 
-        self.logging_config_path = env_get("HC_LOGGING_CONFIG_PATH")
+        self.logging_config_path = env_get("HC_LOGGING_CONFIG_PATH", optional=True)
 
         if self.account_map_type == "file":
             self.account_map_path = env_get("HC_ACCOUNT_MAP_PATH")


### PR DESCRIPTION
Supersedes #274 to break the logging initialization out into its own method while also allowing `logging_config_path` to be optionally defined. If the path is defined but does not exist, we exit with an error instead of silently falling back to the basic logger.