### PR TITLE
Ignore GitHub app installation in route handler

### DIFF
--- a/src/hubcast/web/github/handler.py
+++ b/src/hubcast/web/github/handler.py
@@ -39,6 +39,10 @@ class GitHubHandler:
                 extra={"event_type": event.event, "delivery_id": event.delivery_id},
             )
 
+            # GitHub will notify when a repo installs the Hubcast app; we don't need to handle
+            if event.event in ("installation", "installation_repositories"):
+                return web.Response(status=200)
+
             github_user = event.data["sender"]["login"]
             gitlab_user = self.account_map(github_user)
 


### PR DESCRIPTION
GH will send a request every time an App is installed on a repo, we don't need to handle these requests so ignore them before processing.