### PR TITLE
fix: respect delete_closed config option

### DIFF
--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -325,6 +325,12 @@ async def remove_pr(
     src_fullname = pull_request["head"]["repo"]["full_name"]
     base_fullname = pull_request["base"]["repo"]["full_name"]
 
+    # get the repository configuration from .github/hubcast.yml
+    repo_config, _ = await get_repo_config(gh, base_fullname)
+
+    if not repo_config.delete_closed:
+        return
+
     # if the pull request comes from a fork we should clean up
     # the branch upon closing or merging the PR. However, if the
     # pull request comes from an internal branch we should wait
@@ -336,9 +342,6 @@ async def remove_pr(
 
     pull_request_id = pull_request["number"]
     target_ref = f"refs/heads/pr-{pull_request_id}"
-
-    # get the repository configuration from .github/hubcast.yml
-    repo_config, _ = await get_repo_config(gh, base_fullname)
 
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
     dest_remote_url = f"{gl.instance_url}/{dest_fullname}.git"

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -15,6 +15,7 @@ def create_config(fullname: str, data: dict[str, Any]) -> RepoConfig:
         fullname=fullname,
         dest_org=data["Repo"]["owner"],
         dest_name=data["Repo"]["name"],
+        delete_closed=data["Repo"].get("delete_closed", True),
         sync_drafts=data["Repo"].get("sync_drafts", True),
         sync_drafts_msg=data["Repo"].get("sync_drafts_msg", True),
     )


### PR DESCRIPTION
Repositories can configure if they don't want destination branches to be deleted if the source PR is closed.