### PR TITLE
Parse the check name from the repository config

### DIFF
--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -15,6 +15,7 @@ def create_config(fullname: str, data: dict[str, Any]) -> RepoConfig:
         fullname=fullname,
         dest_org=data["Repo"]["owner"],
         dest_name=data["Repo"]["name"],
+        check_name=data["Repo"].get("check_name", "gitlab-ci"),
         draft_sync=data["Repo"].get("draft_sync", True),
         draft_sync_msg=data["Repo"].get("draft_sync_msg", True),
     )


### PR DESCRIPTION
When constructing the repository config we should check if the user has specified a check name.