### PR TITLE
Add structured exception handling

### DIFF
--- a/src/hubcast/account_map/ldap.py
+++ b/src/hubcast/account_map/ldap.py
@@ -5,6 +5,8 @@ from contextlib import contextmanager
 import ldap
 import ldap.sasl
 
+from hubcast.exceptions import HubcastError
+
 from .abc import AccountMap
 
 log = logging.getLogger(__name__)
@@ -127,10 +129,9 @@ class LDAPMap(AccountMap):
             val = values[0]
             return val.decode() if isinstance(val, bytes) else val
 
-        except ldap.LDAPError:
-            log.exception(
-                "LDAP query failed",
-                extra={"base": self.search_base, "filterstr": filterstr},
+        except ldap.LDAPError as e:
+            raise HubcastError(
+                f"LDAP query failed: {e}",
+                base=self.search_base,
+                filterstr=filterstr,
             )
-
-        return None

--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -6,6 +6,8 @@ import aiohttp
 from gidgethub import HTTPException
 from gidgethub import aiohttp as gh_aiohttp
 
+from hubcast.exceptions import HubcastError
+
 from .auth import GitHubAuthenticator
 
 log = logging.getLogger(__name__)
@@ -143,13 +145,12 @@ class GitHubClient:
                 return await gh.getitem(url, accept="application/vnd.github.raw")
             except HTTPException as exc:
                 if exc.status_code == 404:
-                    log.info(
+                    raise HubcastError(
                         "Repo config file not found at .github/hubcast.yml",
-                        extra={
-                            "repo_owner": self.repo_owner,
-                            "repo_name": self.repo_name,
-                        },
-                    )
+                        log_level="INFO",
+                        repo=f"{self.repo_owner}/{self.repo_name}",
+                    ) from None
+                # all others are unhandled
                 raise
 
     async def get_pr(self, id: int) -> dict[str, Any]:

--- a/src/hubcast/exceptions.py
+++ b/src/hubcast/exceptions.py
@@ -1,0 +1,19 @@
+import logging
+
+
+class HubcastError(Exception):
+    """
+    Exception that stores context for future logging.
+    """
+
+    def __init__(self, message: str, log_level: str = "ERROR", **context):
+        super().__init__(message)
+        self.log_level = log_level.upper()
+        self.context = context
+
+    def log(self, logger: logging.Logger, **extra_context) -> None:
+        """Log this exception with its context and any extra info."""
+        level = getattr(logging, self.log_level)
+        logger.log(
+            level, str(self), extra={**self.context, **extra_context}, exc_info=True
+        )

--- a/src/hubcast/web/github/handler.py
+++ b/src/hubcast/web/github/handler.py
@@ -7,6 +7,7 @@ from gidgethub import sansio
 from hubcast.account_map.abc import AccountMap
 from hubcast.clients.github.client import GitHubClientFactory
 from hubcast.clients.gitlab.client import GitLabClientFactory
+from hubcast.exceptions import HubcastError
 
 from .routes import router
 
@@ -60,6 +61,9 @@ class GitHubHandler:
 
             # return a "Success"
             return web.Response(status=200)
+        except HubcastError as e:
+            e.log(log)
+            return web.Response(status=500)
         except Exception:
             log.exception("Failed to handle Github webhook")
             return web.Response(status=500)

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -7,6 +7,7 @@ from repligit.asyncio import fetch_pack, ls_remote, send_pack
 
 from hubcast.clients.github.client import GitHubClient
 from hubcast.clients.gitlab.client import GitLabClient
+from hubcast.exceptions import HubcastError
 from hubcast.web import comments
 from hubcast.web.github.utils import get_repo_config
 
@@ -24,8 +25,9 @@ class GitHubRouter(routing.Router):
         for callback in found_callbacks:
             try:
                 await callback(event, *args, **kwargs)
+            except HubcastError as e:
+                e.log(log, event_type=event.event, delivery_id=event.delivery_id)
             except Exception:
-                # this catches errors related to processing of webhook events
                 log.exception(
                     "Failed to process GitHub webhook event",
                     extra={

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -1,6 +1,7 @@
 import yaml
 
 from hubcast.clients.github import GitHubClient
+from hubcast.exceptions import HubcastError
 from hubcast.repos.config import RepoConfig
 
 config_cache: dict[str, RepoConfig] = {}
@@ -20,9 +21,8 @@ async def get_repo_config(
         Tuple of (RepoConfig instance, whether it was freshly fetched)
 
     Raises:
-        yaml.YAMLError: If config file contains invalid YAML
-        KeyError: If config is missing required top-level "Repo" key
-        ValueError: If config is missing required fields
+        HubcastError: If config file contains invalid YAML, is missing required keys,
+            or has validation errors
     """
     fetched = False
     if fullname in config_cache and not refresh:
@@ -33,16 +33,23 @@ async def get_repo_config(
         try:
             config_yaml = yaml.safe_load(config_str)
         except yaml.YAMLError as e:
-            raise yaml.YAMLError(f"Invalid YAML in repo config for {fullname}") from e
+            raise HubcastError(
+                f"Invalid YAML in repo config for {fullname}: {e}",
+                repo=fullname,
+            )
 
         try:
             config = RepoConfig.from_yaml_data(config_yaml["Repo"])
         except KeyError as e:
-            raise KeyError(
-                f"Repo config for {fullname} is missing required key: {e}"
-            ) from e
+            raise HubcastError(
+                f"Repo config for {fullname} is missing required key: {e}",
+                repo=fullname,
+            ) from None
         except ValueError as e:
-            raise ValueError(f"Invalid repo config for {fullname}: {e}") from e
+            raise HubcastError(
+                f"Invalid repo config for {fullname}: {e}",
+                repo=fullname,
+            ) from None
 
         config_cache[fullname] = config
         fetched = True

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -35,6 +35,7 @@ async def get_repo_config(
         except yaml.YAMLError as e:
             raise HubcastError(
                 f"Invalid YAML in repo config for {fullname}: {e}",
+                log_level="INFO",
                 repo=fullname,
             )
 
@@ -43,11 +44,13 @@ async def get_repo_config(
         except KeyError as e:
             raise HubcastError(
                 f"Repo config for {fullname} is missing required key: {e}",
+                log_level="INFO",
                 repo=fullname,
             ) from None
         except ValueError as e:
             raise HubcastError(
                 f"Invalid repo config for {fullname}: {e}",
+                log_level="INFO",
                 repo=fullname,
             ) from None
 

--- a/src/hubcast/web/gitlab/handler.py
+++ b/src/hubcast/web/gitlab/handler.py
@@ -6,6 +6,7 @@ from gidgetlab import sansio
 from gidgetlab.exceptions import ValidationFailure
 
 from hubcast.clients.github import GitHubClientFactory
+from hubcast.exceptions import HubcastError
 
 from .routes import router
 
@@ -44,12 +45,14 @@ class GitLabHandler:
 
             # return a "Success"
             return web.Response(status=200)
+        except HubcastError as e:
+            e.log(log)
+            return web.Response(status=500)
         except ValidationFailure:
             log.exception(
                 "Failed to validate Gitlab webhook request",
             )
             return web.Response(status=500)
-
         except Exception:
             log.exception("Failed to handle GitLab webhook")
             return web.Response(status=500)

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -4,6 +4,7 @@ from typing import Any
 from gidgetlab import routing, sansio
 
 from hubcast.clients.github.client import GitHubClient
+from hubcast.exceptions import HubcastError
 
 log = logging.getLogger(__name__)
 
@@ -48,8 +49,9 @@ class GitLabRouter(routing.Router):
         for callback in found_callbacks:
             try:
                 await callback(event, *args, **kwargs)
+            except HubcastError as e:
+                e.log(log, event_type=event.event)
             except Exception:
-                # this catches errors related to processing of webhook events
                 log.exception(
                     "Failed to process GitLab webhook event",
                     extra={


### PR DESCRIPTION
Replace per-exception logging with centralized pattern.

Prevents double logging when errors are caught, logged, and re-raised at
multiple places in the codebase. Instead of logging at each level (eg:
in the generic exception handler and within a route), `HubcastError`s are
raised with context and logged once at the handler.