### PR TITLE
Option for creating merge requests upon PR sync

### DIFF
--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -44,6 +44,11 @@ Repo:
 
   # Optional: post message when draft sync is disabled (default: true)
   sync_drafts_msg: true
+
+  # Optional: create GitLab MRs from GitHub PRs
+  # allows developers to create synthetic merge commits using GitLab's merged results pipelines feature
+  # CI check labels will contain details about the pipeline type (branch, merge request, or merged results)
+  create_mr: false
 ```
 
 A minimal configuration requires only `dest_org` and `dest_name`:

--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -47,7 +47,10 @@ Repo:
 
   # Optional: create GitLab MRs from GitHub PRs
   # allows developers to create synthetic merge commits using GitLab's merged results pipelines feature
-  # CI check labels will contain details about the pipeline type (branch, merge request, or merged results)
+  # CI check labels will contain details about the pipeline type:
+  # [merge request]: pipelines created from a merge between the MR branch and the target branch
+  # [branch]:        pipelines that are created on MR events and run with the HEAD of the branch
+  # [non-mr-branch]: pipelines that are created on all events and run with the HEAD of the branch
   create_mr: false
 ```
 

--- a/src/hubcast/__main__.py
+++ b/src/hubcast/__main__.py
@@ -129,6 +129,7 @@ def main():
     gl_handler = GitLabHandler(
         conf.gl.webhook_secret,
         gh_client_factory,
+        gl_client_factory,
     )
 
     log.info("Starting HTTP server")

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -93,7 +93,7 @@ class GitLabClient:
         gl_fullname: str,
         src_branch: str,
         target_branch: str,
-        ref_id: int,
+        ref_title: int,
         ref_url: str,
     ):
         """Create a merge request in GitLab.
@@ -102,7 +102,7 @@ class GitLabClient:
             gl_fullname: GitLab project name
             src_branch: Source branch for the MR
             target_branch: Target (base) branch for the MR
-            ref_id: GitHub PR number to reference in the MR title
+            ref_title: GitHub PR title
             ref_url: GitHub PR URL to include in the MR description
         """
         gl_token = await self.auth.authenticate_user(username=self.user)
@@ -125,7 +125,7 @@ class GitLabClient:
                 data={
                     "source_branch": src_branch,
                     "target_branch": target_branch,
-                    "title": f"PR from source: #{ref_id}",
+                    "title": ref_title,
                     "description": ref_url,
                 },
             )

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -202,6 +202,26 @@ class GitLabClient:
             url = f"/projects/{repo_id}/hooks/{existing_hook['id']}"
             await gl.put(url, data=new_hook)
 
+    async def get_pipeline(self, gl_fullname: str, pipeline_id: int) -> dict:
+        """Gets a pipeline object for a GitLab project."""
+
+        gl_token = await self.auth.authenticate_user(self.user)
+
+        async with aiohttp.ClientSession() as session:
+            gl = gidgetlab.aiohttp.GitLabAPI(
+                session,
+                requester=self.requester,
+                access_token=gl_token,
+                url=self.instance_url,
+            )
+
+            # temporary fix to support gitlab deployments in sub-paths
+            gl.api_url = f"{self.instance_url}/api/v4/"
+
+            repo_id = urllib.parse.quote_plus(gl_fullname)
+
+            return await gl.getitem(f"/projects/{repo_id}/pipelines/{pipeline_id}")
+
     async def get_latest_pipeline(self, gl_fullname: str, ref: str) -> int:
         """gets the latest pipeline for an arbitrary GitLab repository and branch.
         Returns:

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -83,11 +83,11 @@ class GitLabClient:
             gl.api_url = f"{self.instance_url}/api/v4/"
 
             repo_id = urllib.parse.quote_plus(gl_fullname)
-            filters = f"source_branch={src_branch}&target_branch={target_branch}&state=opened"
-
-            return await gl.getitem(
-                f"/projects/{repo_id}/merge_requests?{filters}"
+            filters = (
+                f"source_branch={src_branch}&target_branch={target_branch}&state=opened"
             )
+
+            return await gl.getitem(f"/projects/{repo_id}/merge_requests?{filters}")
 
     async def create_mr(
         self,

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -83,9 +83,10 @@ class GitLabClient:
             gl.api_url = f"{self.instance_url}/api/v4/"
 
             repo_id = urllib.parse.quote_plus(gl_fullname)
+            filters = f"source_branch={src_branch}&target_branch={target_branch}&state=opened"
 
             return await gl.getitem(
-                f"/projects/{repo_id}/merge_requests?source_branch={src_branch}&target_branch={target_branch}"
+                f"/projects/{repo_id}/merge_requests?{filters}"
             )
 
     async def create_mr(

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -148,7 +148,7 @@ class GitLabClient:
             gh_owner=gh_owner,
             gh_repo=gh_repo,
             gh_check=gh_check,
-            create_mr=self.create_mr,
+            create_mr=create_mr,
         )
         token = routing_token.encode(self.webhook_secret)
 

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -1,6 +1,6 @@
 import logging
 import urllib.parse
-from typing import Literal
+from typing import Any, Literal
 
 import aiohttp
 import gidgetlab.aiohttp
@@ -66,6 +66,70 @@ class GitLabClient:
         self.webhook_secret = webhook_secret
         self.user = user
 
+    async def get_mr(
+        self, gl_fullname: str, src_branch: str, target_branch: str
+    ) -> list[dict[str, Any]]:
+        gl_token = await self.auth.authenticate_user(self.user)
+
+        async with aiohttp.ClientSession() as session:
+            gl = gidgetlab.aiohttp.GitLabAPI(
+                session,
+                requester=self.requester,
+                access_token=gl_token,
+                url=self.instance_url,
+            )
+
+            # temporary fix to support gitlab deployments in sub-paths
+            gl.api_url = f"{self.instance_url}/api/v4/"
+
+            repo_id = urllib.parse.quote_plus(gl_fullname)
+
+            return await gl.getitem(
+                f"/projects/{repo_id}/merge_requests?source_branch={src_branch}&target_branch={target_branch}"
+            )
+
+    async def create_mr(
+        self,
+        gl_fullname: str,
+        src_branch: str,
+        target_branch: str,
+        ref_id: int,
+        ref_url: str,
+    ):
+        """Create a merge request in GitLab.
+
+        Args:
+            gl_fullname: GitLab project name
+            src_branch: Source branch for the MR
+            target_branch: Target (base) branch for the MR
+            ref_id: GitHub PR number to reference in the MR title
+            ref_url: GitHub PR URL to include in the MR description
+        """
+        gl_token = await self.auth.authenticate_user(username=self.user)
+
+        async with aiohttp.ClientSession() as session:
+            gl = gidgetlab.aiohttp.GitLabAPI(
+                session,
+                requester=self.requester,
+                access_token=gl_token,
+                url=self.instance_url,
+            )
+
+            # temporary fix to support gitlab deployments in sub-paths
+            gl.api_url = f"{self.instance_url}/api/v4/"
+
+            repo_id = urllib.parse.quote_plus(gl_fullname)
+
+            await gl.post(
+                f"/projects/{repo_id}/merge_requests",
+                data={
+                    "source_branch": src_branch,
+                    "target_branch": target_branch,
+                    "title": f"PR from source: #{ref_id}",
+                    "description": ref_url,
+                },
+            )
+
     async def set_webhook(
         self,
         dest_org: str,
@@ -74,6 +138,7 @@ class GitLabClient:
         gh_repo: str,
         gh_check: str,
         check_types: list[Literal["pipeline", "jobs"]],
+        create_mr: bool,
     ) -> None:
         gl_token = await self.auth.authenticate_user(username=self.user)
         gl_fullname = f"{dest_org}/{dest_repo}"
@@ -83,6 +148,7 @@ class GitLabClient:
             gh_owner=gh_owner,
             gh_repo=gh_repo,
             gh_check=gh_check,
+            create_mr=self.create_mr,
         )
         token = routing_token.encode(self.webhook_secret)
 
@@ -214,3 +280,26 @@ class GitLabClient:
             )
 
             return pipeline.get("web_url")
+
+    async def get_branch_head(self, gl_fullname: str, branch_name: str) -> str:
+        """Get the HEAD commit SHA of a branch."""
+        gl_token = await self.auth.authenticate_user(self.user)
+
+        async with aiohttp.ClientSession() as session:
+            gl = gidgetlab.aiohttp.GitLabAPI(
+                session,
+                requester=self.requester,
+                access_token=gl_token,
+                url=self.instance_url,
+            )
+
+            # temporary fix to support gitlab deployments in sub-paths
+            gl.api_url = f"{self.instance_url}/api/v4/"
+
+            repo_id = urllib.parse.quote_plus(gl_fullname)
+
+            branch_data = await gl.getitem(
+                f"/projects/{repo_id}/repository/branches/{branch_name}"
+            )
+
+            return branch_data["commit"]["id"]

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -281,8 +281,8 @@ class GitLabClient:
 
             return pipeline.get("web_url")
 
-    async def get_branch_head(self, gl_fullname: str, branch_name: str) -> str:
-        """Get the HEAD commit SHA of a branch."""
+    async def get_commit(self, gl_fullname: str, sha: str) -> dict:
+        """Get details for a commit SHA in a project"""
         gl_token = await self.auth.authenticate_user(self.user)
 
         async with aiohttp.ClientSession() as session:
@@ -298,8 +298,4 @@ class GitLabClient:
 
             repo_id = urllib.parse.quote_plus(gl_fullname)
 
-            branch_data = await gl.getitem(
-                f"/projects/{repo_id}/repository/branches/{branch_name}"
-            )
-
-            return branch_data["commit"]["id"]
+            return await gl.getitem(f"/projects/{repo_id}/repository/commits/{sha}")

--- a/src/hubcast/repos/config.py
+++ b/src/hubcast/repos/config.py
@@ -27,7 +27,7 @@ class RepoConfig(BaseModel):
     # via setting one or more of "pipeline" and/or "jobs"
     check_types: list[Literal["pipeline", "jobs"]] = ["pipeline"]
 
-    # TODO: create GitLab MRs that mirror GitHub PRs to allow users to test
+    # Create GitLab MRs that mirror GitHub PRs to allow users to test
     # synthetic merge commits between the branch and the default branch
     create_mr: bool = False
 

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -241,50 +241,49 @@ async def sync_pr(
     have_shas = set(gl_refs.values())
     from_sha = gl_refs.get(sync_ref) or ("0" * 40)
 
-    if want_sha in have_shas:
+    if want_sha not in have_shas:  # needs sync
+        if is_pull_request_fork and not src_repo_private:
+            # no auth needed for public forks
+            src_creds = {}
+        else:
+            # authenticate if the PR comes from the src repository
+            src_creds = {
+                "username": gh.requester,  # the username doesn't matter, but can't be empty
+                "password": await gh.auth.authenticate_installation(
+                    gh.repo_owner, gh.repo_name
+                ),
+            }
+
+        # fetch differential packfile with all new commits
+        packfile = await fetch_pack(
+            src_repo_url,
+            want_sha,
+            have_shas,
+            **src_creds,
+        )
+
+        # upload packfile to gitlab repository
+        log.info(
+            "Mirroring refs",
+            extra={
+                "from_sha": from_sha,
+                "want_sha": want_sha,
+            },
+        )
+        await send_pack(
+            dest_remote_url,
+            sync_ref,
+            from_sha,
+            want_sha,
+            packfile,
+            username=gl_user,
+            password=gl_token,
+        )
+    else:
         log.info(
             "Destination ref already up-to-date",
             extra={"ref": sync_ref},
         )
-        return
-
-    if is_pull_request_fork and not src_repo_private:
-        # no auth needed for public forks
-        src_creds = {}
-    else:
-        # authenticate if the PR comes from the src repository
-        src_creds = {
-            "username": gh.requester,  # the username doesn't matter, but can't be empty
-            "password": await gh.auth.authenticate_installation(
-                gh.repo_owner, gh.repo_name
-            ),
-        }
-
-    # fetch differential packfile with all new commits
-    packfile = await fetch_pack(
-        src_repo_url,
-        want_sha,
-        have_shas,
-        **src_creds,
-    )
-
-    # upload packfile to gitlab repository
-    log.info(
-        "Mirroring refs",
-        extra={
-            "from_sha": from_sha,
-            "want_sha": want_sha,
-        },
-    )
-    await send_pack(
-        dest_remote_url,
-        sync_ref,
-        from_sha,
-        want_sha,
-        packfile,
-        username=gl_user,
-        password=gl_token,
-    )
 
     # skip already created MRs
     if repo_config.create_mr and not await gl.get_mr(

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -294,7 +294,7 @@ async def sync_pr(
             gl_fullname=dest_fullname,
             src_branch=mr_src_branch,
             target_branch=default_branch,
-            ref_id=pull_request_id,
+            ref_title=pull_request["title"],
             ref_url=pull_request["html_url"],
         )
 

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -241,7 +241,12 @@ async def sync_pr(
     have_shas = set(gl_refs.values())
     from_sha = gl_refs.get(sync_ref) or ("0" * 40)
 
-    if want_sha not in have_shas:  # needs sync
+    if want_sha in have_shas:
+        log.info(
+            "Destination ref already up-to-date",
+            extra={"ref": sync_ref},
+        )
+    else:  # needs sync
         if is_pull_request_fork and not src_repo_private:
             # no auth needed for public forks
             src_creds = {}
@@ -278,11 +283,6 @@ async def sync_pr(
             packfile,
             username=gl_user,
             password=gl_token,
-        )
-    else:
-        log.info(
-            "Destination ref already up-to-date",
-            extra={"ref": sync_ref},
         )
 
     # skip already created MRs

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -52,15 +52,15 @@ async def sync_branch(
     src_owner, src_repo_name = src_fullname.split("/")
     # the commit the push event is referencing
     want_sha = event.data["after"]
-    target_ref = event.data["ref"]
+    sync_ref = event.data["ref"]
 
     # skip branches from push events that are also pull requests
-    if await gh.get_prs(branch=target_ref):
+    if await gh.get_prs(branch=sync_ref):
         return
 
     # only refresh config on default branch pushes (where .github/hubcast.yml lives)
     default_branch = event.data["repository"]["default_branch"]
-    is_default_branch = target_ref == f"refs/heads/{default_branch}"
+    is_default_branch = sync_ref == f"refs/heads/{default_branch}"
     repo_config, fetched = await get_repo_config(
         gh, src_fullname, refresh=is_default_branch
     )
@@ -86,19 +86,19 @@ async def sync_branch(
 
     gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)
     have_shas = set(gl_refs.values())
-    from_sha = gl_refs.get(target_ref) or ("0" * 40)
+    from_sha = gl_refs.get(sync_ref) or ("0" * 40)
 
     if want_sha in have_shas:
         log.info(
-            "Target ref already up-to-date",
-            extra={"target_ref": target_ref},
+            "Destination ref already up-to-date",
+            extra={"ref": sync_ref},
         )
         return
 
     log.info(
         "Mirroring refs",
         extra={
-            "ref": target_ref,
+            "ref": sync_ref,
             "from_sha": from_sha,
             "want_sha": want_sha,
         },
@@ -116,7 +116,7 @@ async def sync_branch(
 
     await send_pack(
         dest_remote_url,
-        target_ref,
+        sync_ref,
         from_sha,
         want_sha,
         packfile,
@@ -127,7 +127,7 @@ async def sync_branch(
     log.info(
         "Successfully mirrored refs",
         extra={
-            "ref": target_ref,
+            "ref": sync_ref,
             "from_sha": from_sha,
             "want_sha": want_sha,
         },
@@ -144,7 +144,7 @@ async def remove_branch(
     **kwargs,
 ) -> None:
     src_fullname = event.data["repository"]["full_name"]
-    target_ref = event.data["ref"]
+    sync_ref = event.data["ref"]
 
     repo_config, _ = await get_repo_config(gh, src_fullname)
 
@@ -154,14 +154,14 @@ async def remove_branch(
     gl_token = await gl.auth.authenticate_user(gl_user)
 
     gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)
-    head_sha = gl_refs.get(target_ref)
+    head_sha = gl_refs.get(sync_ref)
     null_sha = "0" * 40
 
-    log.info("Deleting ref", extra={"target_ref": target_ref})
+    log.info("Deleting ref", extra={"ref": sync_ref})
 
     await send_pack(
         dest_remote_url,
-        target_ref,
+        sync_ref,
         head_sha,
         null_sha,
         b"",
@@ -171,7 +171,7 @@ async def remove_branch(
 
     log.info(
         "Successfully deleted ref",
-        extra={"target_ref": target_ref},
+        extra={"ref": sync_ref},
     )
 
 
@@ -204,9 +204,9 @@ async def sync_pr(
     # between multiple repositories
     is_pull_request_fork = src_fullname != base_fullname
     if is_pull_request_fork:
-        target_ref = f"refs/heads/pr-{pull_request_id}"
+        sync_ref = f"refs/heads/pr-{pull_request_id}"
     else:
-        target_ref = f"refs/heads/{pull_request['head']['ref']}"
+        sync_ref = f"refs/heads/{pull_request['head']['ref']}"
 
     if is_pull_request_fork and src_repo_private:
         # GitHub apps will not have access to private forks
@@ -237,12 +237,12 @@ async def sync_pr(
 
     gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)
     have_shas = set(gl_refs.values())
-    from_sha = gl_refs.get(target_ref) or ("0" * 40)
+    from_sha = gl_refs.get(sync_ref) or ("0" * 40)
 
     if want_sha in have_shas:
         log.info(
-            "Target ref already up-to-date",
-            extra={"target_ref": target_ref},
+            "Destination ref already up-to-date",
+            extra={"ref": sync_ref},
         )
         return
 
@@ -250,7 +250,7 @@ async def sync_pr(
         # no auth needed for public forks
         src_creds = {}
     else:
-        # authenticate if the PR comes from the target repository
+        # authenticate if the PR comes from the src repository
         src_creds = {
             "username": gh.requester,  # the username doesn't matter, but can't be empty
             "password": await gh.auth.authenticate_installation(
@@ -276,7 +276,7 @@ async def sync_pr(
     )
     await send_pack(
         dest_remote_url,
-        target_ref,
+        sync_ref,
         from_sha,
         want_sha,
         packfile,
@@ -284,14 +284,13 @@ async def sync_pr(
         password=gl_token,
     )
 
+    # skip already created MRs
     if repo_config.create_mr and not await gl.get_mr(
-        dest_fullname, target_ref.removeprefix("refs/heads/"), default_branch
-    ):  # skip already created MRs
-        # TODO we still want to create an MR even if the target ref is up to date
+        dest_fullname, sync_ref.removeprefix("refs/heads/"), default_branch
+    ):
         await gl.create_mr(
             gl_fullname=dest_fullname,
-            # TODO the `target_branch` wording here is a bit odd as we usually refer to it as the destination branch we sync to, but for GL MRs it refers to the base for the MR
-            src_branch=target_ref.removeprefix("refs/heads/"),
+            src_branch=sync_ref.removeprefix("refs/heads/"),
             target_branch=default_branch,
             ref_id=pull_request_id,
             ref_url=pull_request["html_url"],
@@ -358,20 +357,20 @@ async def remove_pr(
         return
 
     pull_request_id = pull_request["number"]
-    target_ref = f"refs/heads/pr-{pull_request_id}"
+    sync_ref = f"refs/heads/pr-{pull_request_id}"
 
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
     dest_remote_url = f"{gl.instance_url}/{dest_fullname}.git"
     gl_token = await gl.auth.authenticate_user(gl_user)
 
     gl_refs = await ls_remote(dest_remote_url, username=gl_user, password=gl_token)
-    head_sha = gl_refs.get(target_ref)
+    head_sha = gl_refs.get(sync_ref)
     null_sha = "0" * 40
 
-    log.info("Deleting ref", extra={"target_ref": target_ref})
+    log.info("Deleting ref", extra={"ref": sync_ref})
     await send_pack(
         dest_remote_url,
-        target_ref,
+        sync_ref,
         head_sha,
         null_sha,
         b"",

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -204,11 +204,11 @@ async def sync_pr(
     # between multiple repositories
     is_pull_request_fork = src_fullname != base_fullname
     if is_pull_request_fork:
-        sync_ref = f"refs/heads/pr-{pull_request_id}"
+        sync_branch = f"pr-{pull_request_id}"
     else:
-        sync_ref = f"refs/heads/{pull_request['head']['ref']}"
+        sync_branch = pull_request["head"]["ref"]
 
-    mr_src_branch = sync_ref.removeprefix("refs/heads/")
+    sync_ref = f"refs/heads/{sync_branch}"
 
     if is_pull_request_fork and src_repo_private:
         # GitHub apps will not have access to private forks
@@ -287,11 +287,11 @@ async def sync_pr(
 
     # skip already created MRs
     if repo_config.create_mr and not await gl.get_mr(
-        dest_fullname, mr_src_branch, default_branch
+        dest_fullname, sync_branch, default_branch
     ):
         await gl.create_mr(
             gl_fullname=dest_fullname,
-            src_branch=mr_src_branch,
+            src_branch=sync_branch,
             target_branch=default_branch,
             ref_title=pull_request["title"],
             ref_url=pull_request["html_url"],

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -208,6 +208,8 @@ async def sync_pr(
     else:
         sync_ref = f"refs/heads/{pull_request['head']['ref']}"
 
+    mr_src_branch = sync_ref.removeprefix("refs/heads/")
+
     if is_pull_request_fork and src_repo_private:
         # GitHub apps will not have access to private forks
         log.warning(
@@ -286,11 +288,11 @@ async def sync_pr(
 
     # skip already created MRs
     if repo_config.create_mr and not await gl.get_mr(
-        dest_fullname, sync_ref.removeprefix("refs/heads/"), default_branch
+        dest_fullname, mr_src_branch, default_branch
     ):
         await gl.create_mr(
             gl_fullname=dest_fullname,
-            src_branch=sync_ref.removeprefix("refs/heads/"),
+            src_branch=mr_src_branch,
             target_branch=default_branch,
             ref_id=pull_request_id,
             ref_url=pull_request["html_url"],
@@ -400,7 +402,13 @@ async def respond_pr_comment(
         src_repo_private = pull_request["head"]["repo"]["private"]
         # sync the approved commit explicitly
         await sync_pr(
-            pull_request, gh, gl, gl_user, src_repo_private, want_sha=commit_sha
+            pull_request,
+            gh,
+            gl,
+            gl_user,
+            src_repo_private,
+            want_sha=commit_sha,
+            default_branch=event.data["repository"]["default_branch"],
         )
         await gh.react_to_comment(event.data["review"]["node_id"], "+1")
 

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -78,6 +78,7 @@ async def sync_branch(
             gh_repo=src_repo_name,
             gh_check=repo_config.check_name,
             check_types=repo_config.check_types,
+            create_mr=repo_config.create_mr,
         )
 
     # sync commits from GitHub -> GitLab
@@ -186,6 +187,7 @@ async def sync_pr(
     gl_user: str,
     src_repo_private: bool,
     want_sha: str,
+    default_branch: str,
 ) -> None:
     """Sync the git fork/branch referenced in a PR to GitLab.
 
@@ -282,6 +284,19 @@ async def sync_pr(
         password=gl_token,
     )
 
+    if repo_config.create_mr and not await gl.get_mr(
+        dest_fullname, target_ref.removeprefix("refs/heads/"), default_branch
+    ):  # skip already created MRs
+        # TODO we still want to create an MR even if the target ref is up to date
+        await gl.create_mr(
+            gl_fullname=dest_fullname,
+            # TODO the `target_branch` wording here is a bit odd as we usually refer to it as the destination branch we sync to, but for GL MRs it refers to the base for the MR
+            src_branch=target_ref.removeprefix("refs/heads/"),
+            target_branch=default_branch,
+            ref_id=pull_request_id,
+            ref_url=pull_request["html_url"],
+        )
+
 
 @router.register("pull_request", action="opened")
 @router.register("pull_request", action="reopened")
@@ -303,7 +318,15 @@ async def sync_pr_event(
     else:
         # these events are not triggered by new commits, so we sync the head
         want_sha = pull_request["head"]["sha"]
-    await sync_pr(pull_request, gh, gl, gl_user, src_repo_private, want_sha=want_sha)
+    await sync_pr(
+        pull_request,
+        gh,
+        gl,
+        gl_user,
+        src_repo_private,
+        want_sha=want_sha,
+        default_branch=event.data["repository"]["default_branch"],
+    )
 
 
 @router.register("pull_request", action="closed")

--- a/src/hubcast/web/gitlab/handler.py
+++ b/src/hubcast/web/gitlab/handler.py
@@ -57,7 +57,6 @@ class GitLabHandler:
 
             gl_user = event.data["user"]["username"]
             gitlab_client = self.gitlab_client_factory.create_client(gl_user)
-
             await spawn(
                 request,
                 router.dispatch(

--- a/src/hubcast/web/gitlab/handler.py
+++ b/src/hubcast/web/gitlab/handler.py
@@ -6,6 +6,7 @@ from gidgetlab import sansio
 from gidgetlab.exceptions import ValidationFailure
 
 from hubcast.clients.github import GitHubClientFactory
+from hubcast.clients.gitlab import GitLabClientFactory
 from hubcast.exceptions import HubcastError
 from hubcast.web.gitlab.routes import router
 from hubcast.webhook import RoutingToken, RoutingTokenError
@@ -14,9 +15,15 @@ log = logging.getLogger(__name__)
 
 
 class GitLabHandler:
-    def __init__(self, webhook_secret: str, github_client_factory: GitHubClientFactory):
+    def __init__(
+        self,
+        webhook_secret: str,
+        github_client_factory: GitHubClientFactory,
+        gitlab_client_factory: GitLabClientFactory,
+    ):
         self.webhook_secret = webhook_secret
         self.github_client_factory = github_client_factory
+        self.gitlab_client_factory = gitlab_client_factory
 
     async def handle(self, request: web.Request) -> web.Response:
         try:
@@ -35,6 +42,7 @@ class GitLabHandler:
             gh_repo_owner = routing_token.gh_owner
             gh_repo = routing_token.gh_repo
             gh_check_name = routing_token.gh_check
+            create_mr = routing_token.create_mr
 
             body = await request.read()
 
@@ -47,9 +55,14 @@ class GitLabHandler:
                 gh_repo_owner, gh_repo
             )
 
+            gl_user = event.data["user"]["username"]
+            gitlab_client = self.gitlab_client_factory.create_client(gl_user)
+
             await spawn(
                 request,
-                router.dispatch(event, github_client, gh_check_name),
+                router.dispatch(
+                    event, github_client, gitlab_client, gh_check_name, create_mr
+                ),
             )
 
             # return a "Success"

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -112,7 +112,9 @@ async def pipeline_status_relay(
     status = GITLAB_TO_GITHUB_STATUS.get(pipeline_status)
 
     if status:
-        await gh.set_check_status(commit, name,
+        await gh.set_check_status(
+            commit,
+            name,
             status,
             title="External pipeline run",
             summary=f"[View this pipeline on {urlparse(pipeline_url).netloc}]({pipeline_url})",
@@ -158,7 +160,8 @@ async def job_status_relay(
     status = GITLAB_TO_GITHUB_STATUS.get(job_status)
 
     if status:
-        await gh.set_check_status(commit,
+        await gh.set_check_status(
+            commit,
             name,
             status,
             title="External job run",

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -64,42 +64,13 @@ class GitLabRouter(routing.Router):
 
 router = GitLabRouter()
 
+# STATUS RELAYS
 
-async def _resolve_source_commit(
-    gl: GitLabClient,
-    project_path: str,
-    pipeline_sha: str,
-) -> tuple[str, str]:
-    """
-    To post status back to GitHub, we need to find the sha of the source commit from GitLab.
-    This is trivial for regular pipelines but requires extra checks for MR pipelines.
-
-    Args:
-        gl: GitLab client for API calls
-        project_path: the project namespace and name
-        pipeline_sha: the commit SHA associated with the pipeline
-
-    Returns:
-        Tuple of (source_commit_sha, pipeline_type)
-        - source_commit_sha: The SHA to use for GitHub status updates
-        - pipeline_type: "branch", "merge request", or "merged results"
-    """
-
-    # GitLab creates two types of MR pipelines:
-    # - regular: pipeline_sha is the source branch HEAD
-    # - merged results: pipeline_sha is a synthetic merge commit whose parents are [target HEAD, source HEAD]
-    # The regular MR pipeline is testing the same commit as a branch pipeline.
-    # However, we can't distinguish between the two MR pipeline types from the pipeline webhook payload.
-
-    commit_info = await gl.get_commit(project_path, pipeline_sha)
-    parents = commit_info["parent_ids"]
-
-    # Merged results pipelines: parent_ids == [target HEAD, source HEAD]
-    # Regular MR pipelines: parent_ids == [previous source commit];
-    #   the pipeline SHA itself is already source HEAD.
-    if len(parents) == 2:
-        return parents[1], "merged results"
-    return pipeline_sha, "merge request"
+# To post status back to GitHub, we need to find the sha of the source commit from GitLab.
+# This is trivial for regular pipelines but requires extra checks for MR pipelines.
+# GitLab creates two types of MR pipelines:
+# - regular: pipeline_sha is the source branch HEAD
+# - merged results: pipeline_sha is a synthetic merge commit whose parents are [target HEAD, source HEAD]
 
 
 @router.register("Pipeline Hook")
@@ -119,8 +90,18 @@ async def pipeline_status_relay(
     if not event.data.get("merge_request"):
         commit, pipeline_type = sha, "branch"
     else:
-        # could be either regular MR pipeline or merged results, need to make API call to check
-        commit, pipeline_type = await _resolve_source_commit(gl, project, sha)
+        # to distinguish between the MR pipelines, we need to fetch the pipeline details
+        # and check the ref's suffix
+        pipeline_info = await gl.get_pipeline(
+            project, event.data["object_attributes"]["id"]
+        )
+
+        if pipeline_info["ref"].endswith("/head"):
+            commit, pipeline_type = sha, "merge request"
+        elif pipeline_info["ref"].endswith("/merge"):
+            # API call to extract source HEAD
+            commit_info = await gl.get_commit(project, sha)
+            commit, pipeline_type = commit_info["parent_ids"][1], "merged results"
 
     name = f"{gh_check_name} [{pipeline_type}]" if create_mr else gh_check_name
 
@@ -158,11 +139,11 @@ async def job_status_relay(
     if not is_mr_event:
         commit, pipeline_type = sha, "branch"
     elif ref.endswith("/head"):
-        # regular MR pipeline; job hook exposes the type, no API call needed
         commit, pipeline_type = sha, "merge request"
     elif ref.endswith("/merge"):
-        # merged results pipeline; need API call to extract source HEAD
-        commit, pipeline_type = await _resolve_source_commit(gl, project, sha)
+        # API call to extract source HEAD
+        commit_info = await gl.get_commit(project, sha)
+        commit, pipeline_type = commit_info["parent_ids"][1], "merged results"
 
     job_id = event.data["build_id"]
     job_name = event.data["build_name"]

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 from gidgetlab import routing, sansio
 
 from hubcast.clients.github.client import GitHubClient
+from hubcast.clients.gitlab.client import GitLabClient
 from hubcast.exceptions import HubcastError
 
 log = logging.getLogger(__name__)
@@ -66,11 +67,41 @@ router = GitLabRouter()
 
 @router.register("Pipeline Hook")
 async def pipeline_status_relay(
-    event: sansio.Event, gh: GitHubClient, gh_check_name: str, *arg, **kwargs
+    event: sansio.Event,
+    gh: GitHubClient,
+    gl: GitLabClient,
+    gh_check_name: str,
+    create_mr: bool,
+    *args,
+    **kwargs,
 ) -> None:
     """Relay status of a GitLab pipeline back to GitHub."""
     # get ref from event
     ref = event.data["object_attributes"]["sha"]
+
+    # GitLab creates two types of MR pipelines:
+    # - regular: event.commit.id is the actual source commit
+    # - merged results: event.commit.id is a synthetic merge commit
+    # we cannot reliably distinguish between these two types from the webhook payload
+    # without making an API call, so we fetch the source branch HEAD to update the GitHub check
+    # associated with the source commit.
+
+    is_mr_event = (
+        event.data["object_attributes"]["source"] == "merge_request_event"
+        and "merge_request" in event.data
+    )
+    if is_mr_event:
+        source_branch = event.data["merge_request"]["source_branch"]
+        gl_fullname = event.data["project"]["path_with_namespace"]
+        ref = await gl.get_branch_head(gl_fullname, source_branch)
+
+    # modify check name based on the pipeline source
+    check_name = gh_check_name
+    if create_mr:
+        if is_mr_event:
+            check_name = f"{gh_check_name} [merge request]"
+        else:
+            check_name = f"{gh_check_name} [branch]"
 
     # get status from event
     pipeline_status = event.data["object_attributes"]["status"]
@@ -80,8 +111,7 @@ async def pipeline_status_relay(
 
     if status:
         await gh.set_check_status(
-            ref,
-            gh_check_name,
+            ref, check_name,
             status,
             title="External pipeline run",
             summary=f"[View this pipeline on {urlparse(pipeline_url).netloc}]({pipeline_url})",

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -96,12 +96,9 @@ async def pipeline_status_relay(
         ref = await gl.get_branch_head(gl_fullname, source_branch)
 
     # modify check name based on the pipeline source
-    check_name = gh_check_name
     if create_mr:
-        if is_mr_event:
-            check_name = f"{gh_check_name} [merge request]"
-        else:
-            check_name = f"{gh_check_name} [branch]"
+        suffix = "merge request" if is_mr_event else "branch"
+    name = f"{gh_check_name} [{suffix}]" if suffix else gh_check_name
 
     # get status from event
     pipeline_status = event.data["object_attributes"]["status"]
@@ -111,7 +108,7 @@ async def pipeline_status_relay(
 
     if status:
         await gh.set_check_status(
-            ref, check_name,
+            ref, name,
             status,
             title="External pipeline run",
             summary=f"[View this pipeline on {urlparse(pipeline_url).netloc}]({pipeline_url})",
@@ -121,7 +118,12 @@ async def pipeline_status_relay(
 
 @router.register("Job Hook")
 async def job_status_relay(
-    event: sansio.Event, gh: GitHubClient, gh_check_name: str, *arg, **kwargs
+    event: sansio.Event,
+    gh: GitHubClient,
+    gl: GitLabClient,
+    gh_check_name: str,
+    *arg,
+    **kwargs,
 ) -> None:
     """Relay status of a GitLab job back to GitHub."""
     # get ref from event

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -88,7 +88,7 @@ async def pipeline_status_relay(
     project = event.data["project"]["path_with_namespace"]
 
     if not event.data.get("merge_request"):
-        commit, pipeline_type = sha, "branch"
+        commit, pipeline_type = sha, "non-mr-branch"
     else:
         # to distinguish between the MR pipelines, we need to fetch the pipeline details
         # and check the ref's suffix
@@ -97,11 +97,11 @@ async def pipeline_status_relay(
         )
 
         if pipeline_info["ref"].endswith("/head"):
-            commit, pipeline_type = sha, "merge request"
+            commit, pipeline_type = sha, "branch"
         elif pipeline_info["ref"].endswith("/merge"):
             # API call to extract source HEAD
             commit_info = await gl.get_commit(project, sha)
-            commit, pipeline_type = commit_info["parent_ids"][1], "merged results"
+            commit, pipeline_type = commit_info["parent_ids"][1], "merge request"
 
     name = f"{gh_check_name} [{pipeline_type}]" if create_mr else gh_check_name
 
@@ -137,13 +137,13 @@ async def job_status_relay(
     is_mr_event = ref.startswith("refs/merge-requests/")
 
     if not is_mr_event:
-        commit, pipeline_type = sha, "branch"
+        commit, pipeline_type = sha, "non-mr-branch"
     elif ref.endswith("/head"):
-        commit, pipeline_type = sha, "merge request"
+        commit, pipeline_type = sha, "branch"
     elif ref.endswith("/merge"):
         # API call to extract source HEAD
         commit_info = await gl.get_commit(project, sha)
-        commit, pipeline_type = commit_info["parent_ids"][1], "merged results"
+        commit, pipeline_type = commit_info["parent_ids"][1], "merge request"
 
     job_id = event.data["build_id"]
     job_name = event.data["build_name"]

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -89,7 +89,7 @@ async def _resolve_source_commit(
     # - regular: pipeline_sha is the source branch HEAD
     # - merged results: pipeline_sha is a synthetic merge commit whose parents are [target HEAD, source HEAD]
     # The regular MR pipeline is testing the same commit as a branch pipeline.
-    # However, we can't distinguish between the two MR pipeline types from the webhook payload.
+    # However, we can't distinguish between the two MR pipeline types from the pipeline webhook payload.
 
     commit_info = await gl.get_commit(project_path, pipeline_sha)
     parents = commit_info["parent_ids"]

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -65,6 +65,43 @@ class GitLabRouter(routing.Router):
 router = GitLabRouter()
 
 
+async def _resolve_source_commit(
+    gl: GitLabClient,
+    project_path: str,
+    pipeline_sha: str,
+) -> tuple[str, str]:
+    """
+    To post status back to GitHub, we need to find the sha of the source commit from GitLab.
+    This is trivial for regular pipelines but requires extra checks for MR pipelines.
+
+    Args:
+        gl: GitLab client for API calls
+        project_path: the project namespace and name
+        pipeline_sha: the commit SHA associated with the pipeline
+
+    Returns:
+        Tuple of (source_commit_sha, pipeline_type)
+        - source_commit_sha: The SHA to use for GitHub status updates
+        - pipeline_type: "branch", "merge request", or "merged results"
+    """
+
+    # GitLab creates two types of MR pipelines:
+    # - regular: pipeline_sha is the source branch HEAD
+    # - merged results: pipeline_sha is a synthetic merge commit whose parents are [target HEAD, source HEAD]
+    # The regular MR pipeline is testing the same commit as a branch pipeline.
+    # However, we can't distinguish between the two MR pipeline types from the webhook payload.
+
+    commit_info = await gl.get_commit(project_path, pipeline_sha)
+    parents = commit_info["parent_ids"]
+
+    # Merged results pipelines: parent_ids == [target HEAD, source HEAD]
+    # Regular MR pipelines: parent_ids == [previous source commit];
+    #   the pipeline SHA itself is already source HEAD.
+    if len(parents) == 2:
+        return parents[1], "merged results"
+    return pipeline_sha, "merge request"
+
+
 @router.register("Pipeline Hook")
 async def pipeline_status_relay(
     event: sansio.Event,
@@ -76,29 +113,16 @@ async def pipeline_status_relay(
     **kwargs,
 ) -> None:
     """Relay status of a GitLab pipeline back to GitHub."""
-    # get ref from event
-    ref = event.data["object_attributes"]["sha"]
+    sha = event.data["object_attributes"]["sha"]
+    project = event.data["project"]["path_with_namespace"]
 
-    # GitLab creates two types of MR pipelines:
-    # - regular: event.commit.id is the actual source commit
-    # - merged results: event.commit.id is a synthetic merge commit
-    # we cannot reliably distinguish between these two types from the webhook payload
-    # without making an API call, so we fetch the source branch HEAD to update the GitHub check
-    # associated with the source commit.
+    if not event.data.get("merge_request"):
+        commit, pipeline_type = sha, "branch"
+    else:
+        # could be either regular MR pipeline or merged results, need to make API call to check
+        commit, pipeline_type = await _resolve_source_commit(gl, project, sha)
 
-    is_mr_event = (
-        event.data["object_attributes"]["source"] == "merge_request_event"
-        and "merge_request" in event.data
-    )
-    if is_mr_event:
-        source_branch = event.data["merge_request"]["source_branch"]
-        gl_fullname = event.data["project"]["path_with_namespace"]
-        ref = await gl.get_branch_head(gl_fullname, source_branch)
-
-    # modify check name based on the pipeline source
-    if create_mr:
-        suffix = "merge request" if is_mr_event else "branch"
-    name = f"{gh_check_name} [{suffix}]" if suffix else gh_check_name
+    name = f"{gh_check_name} [{pipeline_type}]" if create_mr else gh_check_name
 
     # get status from event
     pipeline_status = event.data["object_attributes"]["status"]
@@ -107,8 +131,7 @@ async def pipeline_status_relay(
     status = GITLAB_TO_GITHUB_STATUS.get(pipeline_status)
 
     if status:
-        await gh.set_check_status(
-            ref, name,
+        await gh.set_check_status(commit, name,
             status,
             title="External pipeline run",
             summary=f"[View this pipeline on {urlparse(pipeline_url).netloc}]({pipeline_url})",
@@ -122,12 +145,24 @@ async def job_status_relay(
     gh: GitHubClient,
     gl: GitLabClient,
     gh_check_name: str,
-    *arg,
+    create_mr: bool,
+    *args,
     **kwargs,
 ) -> None:
     """Relay status of a GitLab job back to GitHub."""
-    # get ref from event
-    ref = event.data["sha"]
+    sha = event.data["sha"]
+    project = event.data["project"]["path_with_namespace"]
+    ref = event.data.get("ref", "")
+    is_mr_event = ref.startswith("refs/merge-requests/")
+
+    if not is_mr_event:
+        commit, pipeline_type = sha, "branch"
+    elif ref.endswith("/head"):
+        # regular MR pipeline; job hook exposes the type, no API call needed
+        commit, pipeline_type = sha, "merge request"
+    elif ref.endswith("/merge"):
+        # merged results pipeline; need API call to extract source HEAD
+        commit, pipeline_type = await _resolve_source_commit(gl, project, sha)
 
     job_id = event.data["build_id"]
     job_name = event.data["build_name"]
@@ -137,11 +172,12 @@ async def job_status_relay(
     job_url = f"{repository_url}/-/jobs/{job_id}"
 
     name = f"{gh_check_name} / {job_name}" if gh_check_name else job_name
+    name = f"{name} [{pipeline_type}]" if create_mr else name
+
     status = GITLAB_TO_GITHUB_STATUS.get(job_status)
 
     if status:
-        await gh.set_check_status(
-            ref,
+        await gh.set_check_status(commit,
             name,
             status,
             title="External job run",

--- a/src/hubcast/webhook/token.py
+++ b/src/hubcast/webhook/token.py
@@ -25,6 +25,7 @@ class RoutingToken(BaseModel):
     gh_owner: str
     gh_repo: str
     gh_check: str
+    create_mr: bool
 
     def encode(self, secret: str) -> str:
         """Generate a cryptographically signed JWT token.


### PR DESCRIPTION
This PR allows repo maintainers to set the `create_mr` option, which will create a merge request on the destination GitLab repo. The status relay has been updated to handle multiple pipelines created per sync event, distinguishing between branch and MR pipelines.

TODO:

- [x] clean up some of the overlapping terminology (target, base, etc)
- [x] document the feature
- [x] address TODOs