### PR TITLE
Update routing token generation to accept arbitrary config values

### DIFF
--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -67,9 +67,9 @@ class GitLabClient:
 
         # Generate unique signed token for this webhook containing routing information.
         # This token serves as the GitLab webhook secret and encodes routing information
-        # (GitHub owner, repo, check name) in a tamper-proof JWT format. When GitLab sends
-        # webhook events, we validate this token to extract routing details and determine
-        # where to report CI status back to GitHub.
+        # (GitHub owner, repo, check name) in a tamper-proof JWT format. When GitLab
+        # sends webhook events, we validate this token to extract routing details and
+        # determine where to report CI status back to GitHub.
         required_fields = {"gh_owner", "gh_repo", "gh_check"}
         missing_fields = required_fields - data.keys()
         if missing_fields:
@@ -78,7 +78,8 @@ class GitLabClient:
                 "Expected keys: gh_owner, gh_repo, gh_check"
             )
 
-        # Must be present in JWT_ALGORITHMS in src/hubcast/web/gitlab/routing_token.py
+        # Algorithm must be present in JWT_ALGORITHMS in
+        # src/hubcast/web/gitlab/routing_token.py for decode
         token = jwt.encode(data, self.webhook_secret, algorithm="HS256")
 
         new_hook = {

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -65,7 +65,11 @@ class GitLabClient:
     async def set_webhook(self, gl_fullname: str, data: dict[str, str]) -> None:
         gl_token = await self.auth.authenticate_user(username=self.user)
 
-        # Generate unique signed token for this webhook containing routing information
+        # Generate unique signed token for this webhook containing routing information.
+        # This token serves as the GitLab webhook secret and encodes routing information
+        # (GitHub owner, repo, check name) in a tamper-proof JWT format. When GitLab sends
+        # webhook events, we validate this token to extract routing details and determine
+        # where to report CI status back to GitHub.
         required_fields = {"gh_owner", "gh_repo", "gh_check"}
         missing_fields = required_fields - data.keys()
         if missing_fields:

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -3,8 +3,7 @@ import urllib.parse
 
 import aiohttp
 import gidgetlab
-
-from hubcast.web.utils import generate_routing_token
+import jwt
 
 from .auth import GitLabAuthenticator, GitLabSingleUserAuthenticator
 
@@ -67,18 +66,16 @@ class GitLabClient:
         gl_token = await self.auth.authenticate_user(username=self.user)
 
         # Generate unique signed token for this webhook containing routing information
-        try:
-            token = generate_routing_token(
-                self.webhook_secret,
-                data["gh_owner"],
-                data["gh_repo"],
-                data["gh_check"],
-            )
-        except KeyError as e:
+        required_fields = {"gh_owner", "gh_repo", "gh_check"}
+        missing_fields = required_fields - data.keys()
+        if missing_fields:
             raise ValueError(
-                f"Missing required webhook data field: {e}. "
+                f"Missing required webhook data fields: {', '.join(sorted(missing_fields))}. "
                 "Expected keys: gh_owner, gh_repo, gh_check"
-            ) from e
+            )
+
+        # Must be present in JWT_ALGORITHMS in src/hubcast/web/gitlab/routing_token.py
+        token = jwt.encode(data, self.webhook_secret, algorithm="HS256")
 
         new_hook = {
             "token": token,

--- a/src/hubcast/web/gitlab/handler.py
+++ b/src/hubcast/web/gitlab/handler.py
@@ -8,8 +8,8 @@ from gidgetlab.exceptions import ValidationFailure
 from hubcast.clients.github import GitHubClientFactory
 from hubcast.exceptions import HubcastError
 
-from .routing_token import RoutingTokenError, validate_routing_token
 from .routes import router
+from .routing_token import RoutingTokenError, validate_routing_token
 
 log = logging.getLogger(__name__)
 

--- a/src/hubcast/web/gitlab/handler.py
+++ b/src/hubcast/web/gitlab/handler.py
@@ -7,8 +7,8 @@ from gidgetlab.exceptions import ValidationFailure
 
 from hubcast.clients.github import GitHubClientFactory
 from hubcast.exceptions import HubcastError
-from hubcast.web.utils import RoutingTokenError, validate_routing_token
 
+from .routing_token import RoutingTokenError, validate_routing_token
 from .routes import router
 
 log = logging.getLogger(__name__)

--- a/src/hubcast/web/gitlab/routing_token.py
+++ b/src/hubcast/web/gitlab/routing_token.py
@@ -2,40 +2,13 @@ import jwt
 
 from hubcast.exceptions import HubcastError
 
-# If this is changed we should add the previous value to the decode
-# method's list to allow for backwards compatibility while webhooks
-# are migrated over time
-JWT_ALGORITHM = "HS256"
+# Old algorithms should be kept in the list for a couple releases to
+# give instances time to migrate webhooks over time
+JWT_ALGORITHMS = ["HS256"]
 
 
 class RoutingTokenError(HubcastError):
     """Raised when routing token validation fails."""
-
-
-def generate_routing_token(
-    secret: str, gh_owner: str, gh_repo: str, gh_check: str
-) -> str:
-    """Generate a cryptographically signed routing token using JWT.
-
-    This token serves as the GitLab webhook secret and encodes routing information
-    (GitHub owner, repo, check name) in a tamper-proof JWT format.
-
-    Args:
-        secret: HMAC signing key
-        gh_owner: GitHub repository owner
-        gh_repo: GitHub repository name
-        gh_check: GitHub check name to report status to
-
-    Returns:
-        JWT token signed with HMAC-SHA256
-    """
-    payload = {
-        "gh_owner": gh_owner,
-        "gh_repo": gh_repo,
-        "gh_check": gh_check,
-    }
-
-    return jwt.encode(payload, secret, algorithm=JWT_ALGORITHM)
 
 
 def validate_routing_token(secret: str, token: str) -> dict[str, str]:
@@ -53,7 +26,7 @@ def validate_routing_token(secret: str, token: str) -> dict[str, str]:
                           or payload is missing required fields
     """
     try:
-        payload = jwt.decode(token, secret, algorithms=[JWT_ALGORITHM])
+        payload = jwt.decode(token, secret, algorithms=JWT_ALGORITHMS)
     except jwt.InvalidTokenError as e:
         raise RoutingTokenError(
             f"Invalid routing token: {e}",
@@ -70,8 +43,4 @@ def validate_routing_token(secret: str, token: str) -> dict[str, str]:
             missing_fields=sorted(missing_fields),
         )
 
-    return {
-        "gh_owner": payload["gh_owner"],
-        "gh_repo": payload["gh_repo"],
-        "gh_check": payload["gh_check"],
-    }
+    return payload


### PR DESCRIPTION
Refactor of the routing token logic to get rid of the circular dependency between `web/util.py` and `clients/gitlab/client.py`. 

Additionally made it so that we can set arbitrary configuration values in the token for the future.