### PR TITLE
Small updates to accountmaps style

### DIFF
--- a/src/hubcast/__main__.py
+++ b/src/hubcast/__main__.py
@@ -72,8 +72,8 @@ def initialize_account_map(conf: Config) -> AccountMap:
         case FileAccountMapConfig(path=path):
             try:
                 return FileMap(path)
-            except FileMapError:
-                log.exception("Error initializing file account map")
+            except FileMapError as e:
+                e.log(log)
                 sys.exit(1)
 
         case LDAPAccountMapConfig() as ldap_config:

--- a/src/hubcast/account_map/abc.py
+++ b/src/hubcast/account_map/abc.py
@@ -13,4 +13,3 @@ class AccountMap(ABC):
         Return the corresponding destination forge user for a given source forge user
         if one exists.
         """
-        pass

--- a/src/hubcast/account_map/file.py
+++ b/src/hubcast/account_map/file.py
@@ -2,10 +2,12 @@ from pathlib import Path
 
 import yaml
 
+from hubcast.exceptions import HubcastError
+
 from .abc import AccountMap
 
 
-class FileMapError(Exception):
+class FileMapError(HubcastError):
     pass
 
 

--- a/src/hubcast/account_map/file.py
+++ b/src/hubcast/account_map/file.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import yaml
 
 from .abc import AccountMap
@@ -21,24 +23,25 @@ class FileMap(AccountMap):
         A filepath to the users.yml defining a usermapping.
     """
 
-    path: str
+    path: Path
     users: dict[str, str]
 
-    def __init__(self, path: str):
+    def __init__(self, path: Path | str):
         """
         Constructor, path to read from and generate a simple account
         mapping between services.
         """
-        self.path = path
+        self.path = Path(path)
 
         try:
-            with open(path, "r") as f:
-                data = yaml.safe_load(f)
-                self.users = data["Users"]
-        except FileNotFoundError:
-            raise FileMapError(f"File map not found. path={path}")
-        except yaml.YAMLError:
-            raise FileMapError(f"Failed to parse file map. path={path}")
+            data = yaml.safe_load(self.path.read_text())
+            self.users = data["Users"]
+        except FileNotFoundError as e:
+            raise FileMapError(f"File map not found. path={path}") from e
+        except yaml.YAMLError as e:
+            raise FileMapError(f"Failed to parse file map. path={path}") from e
+        except (KeyError, TypeError) as e:
+            raise FileMapError(f"File map missing Users section. path={path}") from e
 
     def __call__(self, source_user: str) -> str | None:
         """

--- a/src/hubcast/account_map/ldap.py
+++ b/src/hubcast/account_map/ldap.py
@@ -135,4 +135,4 @@ class LDAPMap(AccountMap):
                 f"LDAP query failed: {e}",
                 base=self.search_base,
                 filterstr=filterstr,
-            )
+            ) from e


### PR DESCRIPTION
- Use pathlib for better input path validation
- Switch to `path.read_text()` for better UTF-8 validation
- Add `from exception` to keep exception context in account mapping errors