### PR TITLE
Simplify GitLabRouter by calling super().dispatch

### DIFF
--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -27,34 +27,16 @@ GITLAB_TO_GITHUB_STATUS = {
 
 class GitLabRouter(routing.Router):
     """
-    Custom router to handle common interactions for hubcast
+    Custom router to better handle logging of errors
     """
 
     async def dispatch(self, event: sansio.Event, *args: Any, **kwargs: Any) -> None:
-        """Dispatch an event to all registered function(s)."""
-
-        found_callbacks = []
         try:
-            found_callbacks.extend(self._shallow_routes[event.event])
-        except KeyError:
-            pass
-        try:
-            details = self._deep_routes[event.event]
-        except KeyError:
-            pass
-        else:
-            for data_key, data_values in details.items():
-                if data_key in event.object_attributes:
-                    event_value = event.object_attributes[data_key]
-                    if event_value in data_values:
-                        found_callbacks.extend(data_values[event_value])
-        for callback in found_callbacks:
-            try:
-                await callback(event, *args, **kwargs)
-            except HubcastError as e:
-                e.log(log)
-            except Exception:
-                log.exception("Failed to process GitLab webhook event")
+            await super().dispatch(event, *args, **kwargs)
+        except HubcastError as e:
+            e.log(log)
+        except Exception:
+            log.exception("Failed to process GitLab webhook event")
 
 
 router = GitLabRouter()


### PR DESCRIPTION
Reuse the existing logic in `super().dispatch` instead of copying the method into Hubcast to reduce maintenance.