### PR TITLE
Reduce the number of "queued" statuses relayed

### DIFF
--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -14,9 +14,7 @@ log = logging.getLogger(__name__)
 # https://docs.gitlab.com/api/pipelines/#list-project-pipelines -> status description
 # not mapping all statuses to avoid churn in posting updates
 GITLAB_TO_GITHUB_STATUS = {
-    "created": "queued",
     "pending": "queued",
-    "manual": "queued",
     "running": "in_progress",
     "failed": "failure",
     "canceled": "cancelled",


### PR DESCRIPTION
In my testing relaying all of these statuses sometimes caused GitHub jobs not to update to the "running" status.

Since we always get a pending call I think we should reduce the number of alternate statues we render.
(I'm not sure if we should be relaying manual jobs before they're started since that'll show a PR as waiting CI that may never run.)