### PR TITLE
Remove logic for determining non-pr-branch, branch, and mr suffixes

### DIFF
--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -139,7 +139,6 @@ class GitLabClient:
         gh_repo: str,
         gh_check: str,
         check_types: list[Literal["pipeline", "jobs"]],
-        create_mr: bool,
     ) -> None:
         gl_token = await self.auth.authenticate_user(username=self.user)
         gl_fullname = f"{dest_org}/{dest_repo}"
@@ -149,7 +148,6 @@ class GitLabClient:
             gh_owner=gh_owner,
             gh_repo=gh_repo,
             gh_check=gh_check,
-            create_mr=create_mr,
         )
         token = routing_token.encode(self.webhook_secret)
 
@@ -200,26 +198,6 @@ class GitLabClient:
             # otherwise update the existing hook with the new config
             url = f"/projects/{repo_id}/hooks/{existing_hook['id']}"
             await gl.put(url, data=new_hook)
-
-    async def get_pipeline(self, gl_fullname: str, pipeline_id: int) -> dict:
-        """Gets a pipeline object for a GitLab project."""
-
-        gl_token = await self.auth.authenticate_user(self.user)
-
-        async with aiohttp.ClientSession() as session:
-            gl = gidgetlab.aiohttp.GitLabAPI(
-                session,
-                requester=self.requester,
-                access_token=gl_token,
-                url=self.instance_url,
-            )
-
-            # temporary fix to support gitlab deployments in sub-paths
-            gl.api_url = f"{self.instance_url}/api/v4/"
-
-            repo_id = urllib.parse.quote_plus(gl_fullname)
-
-            return await gl.getitem(f"/projects/{repo_id}/pipelines/{pipeline_id}")
 
     async def get_latest_pipeline(self, gl_fullname: str, ref: str) -> int:
         """gets the latest pipeline for an arbitrary GitLab repository and branch.

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -199,6 +199,26 @@ class GitLabClient:
             url = f"/projects/{repo_id}/hooks/{existing_hook['id']}"
             await gl.put(url, data=new_hook)
 
+    async def get_pipeline(self, gl_fullname: str, pipeline_id: int) -> dict:
+        """Gets a pipeline object for a GitLab project."""
+
+        gl_token = await self.auth.authenticate_user(self.user)
+
+        async with aiohttp.ClientSession() as session:
+            gl = gidgetlab.aiohttp.GitLabAPI(
+                session,
+                requester=self.requester,
+                access_token=gl_token,
+                url=self.instance_url,
+            )
+
+            # temporary fix to support gitlab deployments in sub-paths
+            gl.api_url = f"{self.instance_url}/api/v4/"
+
+            repo_id = urllib.parse.quote_plus(gl_fullname)
+
+            return await gl.getitem(f"/projects/{repo_id}/pipelines/{pipeline_id}")
+
     async def get_latest_pipeline(self, gl_fullname: str, ref: str) -> int:
         """gets the latest pipeline for an arbitrary GitLab repository and branch.
         Returns:

--- a/src/hubcast/config.py
+++ b/src/hubcast/config.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, Union
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -88,7 +88,7 @@ class LDAPAccountMapConfig(BaseModel):
 
 
 AccountMapConfig = Annotated[
-    Union[FileAccountMapConfig, LDAPAccountMapConfig],
+    FileAccountMapConfig | LDAPAccountMapConfig,
     Field(discriminator="type"),
 ]
 

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -78,7 +78,6 @@ async def sync_branch(
             gh_repo=src_repo_name,
             gh_check=repo_config.check_name,
             check_types=repo_config.check_types,
-            create_mr=repo_config.create_mr,
         )
 
     # sync commits from GitHub -> GitLab

--- a/src/hubcast/web/gitlab/handler.py
+++ b/src/hubcast/web/gitlab/handler.py
@@ -43,7 +43,6 @@ class GitLabHandler:
             gh_repo_owner = routing_token.gh_owner
             gh_repo = routing_token.gh_repo
             gh_check_name = routing_token.gh_check
-            create_mr = routing_token.create_mr
 
             body = await request.read()
 
@@ -68,9 +67,7 @@ class GitLabHandler:
             gitlab_client = self.gitlab_client_factory.create_client(gl_user)
             await spawn(
                 request,
-                router.dispatch(
-                    event, github_client, gitlab_client, gh_check_name, create_mr
-                ),
+                router.dispatch(event, github_client, gitlab_client, gh_check_name),
             )
 
             # return a "Success"

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -17,7 +17,7 @@ GITLAB_TO_GITHUB_STATUS = {
     "pending": "queued",
     "running": "in_progress",
     "failed": "failure",
-    "canceled": "cancelled",
+    "canceled": "cancelled",  # Not a typo, GitHub with two Ls
     "skipped": "skipped",
     "success": "success",
 }
@@ -54,40 +54,32 @@ async def pipeline_status_relay(
     gh: GitHubClient,
     gl: GitLabClient,
     gh_check_name: str,
-    create_mr: bool,
     *args,
     **kwargs,
 ) -> None:
     """Relay status of a GitLab pipeline back to GitHub."""
+
     pipeline_status = event.data["object_attributes"]["status"]
     status = GITLAB_TO_GITHUB_STATUS.get(pipeline_status)
     if not status:
         return
 
-    sha = event.data["object_attributes"]["sha"]
     project = event.data["project"]["path_with_namespace"]
+    ref = event.data["object_attributes"].get("ref", "")
+    sha = event.data["object_attributes"]["sha"]
 
-    if not event.data.get("merge_request"):
-        commit, pipeline_type = sha, "non-mr-branch"
-    else:
-        # to distinguish between the MR pipelines, we need to fetch the pipeline details
-        # and check the ref's suffix
-        pipeline_info = await gl.get_pipeline(
-            project, event.data["object_attributes"]["id"]
-        )
+    if event.data.get("merge_request") and ref.endswith("/merge"):
+        # MR merge pipelines use a synthetic merge commit, so report the source
+        # commit status back to GitHub instead.
+        commit_info = await gl.get_commit(project, sha)
+        sha = commit_info["parent_ids"][1]
 
-        if pipeline_info["ref"].endswith("/head"):
-            commit, pipeline_type = sha, "branch"
-        elif pipeline_info["ref"].endswith("/merge"):
-            # API call to extract source HEAD
-            commit_info = await gl.get_commit(project, sha)
-            commit, pipeline_type = commit_info["parent_ids"][1], "merge request"
+    name = gh_check_name
 
-    name = f"{gh_check_name} [{pipeline_type}]" if create_mr else gh_check_name
     pipeline_url = event.data["object_attributes"]["url"]
 
     await gh.set_check_status(
-        commit,
+        sha,
         name,
         status,
         title="External pipeline run",
@@ -102,7 +94,6 @@ async def job_status_relay(
     gh: GitHubClient,
     gl: GitLabClient,
     gh_check_name: str,
-    create_mr: bool,
     *args,
     **kwargs,
 ) -> None:
@@ -112,19 +103,15 @@ async def job_status_relay(
     if not status:
         return
 
-    sha = event.data["sha"]
     project = event.data["project"]["path_with_namespace"]
     ref = event.data.get("ref", "")
-    is_mr_event = ref.startswith("refs/merge-requests/")
+    sha = event.data["sha"]
 
-    if not is_mr_event:
-        commit, pipeline_type = sha, "non-mr-branch"
-    elif ref.endswith("/head"):
-        commit, pipeline_type = sha, "branch"
-    elif ref.endswith("/merge"):
-        # API call to extract source HEAD
+    if ref.startswith("refs/merge-requests/") and ref.endswith("/merge"):
+        # MR merge jobs use a synthetic merge commit, so report the source
+        # commit status back to GitHub instead.
         commit_info = await gl.get_commit(project, sha)
-        commit, pipeline_type = commit_info["parent_ids"][1], "merge request"
+        sha = commit_info["parent_ids"][1]
 
     job_id = event.data["build_id"]
     job_name = event.data["build_name"]
@@ -133,10 +120,9 @@ async def job_status_relay(
     job_url = f"{repository_url}/-/jobs/{job_id}"
 
     name = f"{gh_check_name} / {job_name}" if gh_check_name else job_name
-    name = f"{name} [{pipeline_type}]" if create_mr else name
 
     await gh.set_check_status(
-        commit,
+        sha,
         name,
         status,
         title="External job run",

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -65,17 +65,21 @@ async def pipeline_status_relay(
         return
 
     project = event.data["project"]["path_with_namespace"]
-    ref = event.data["object_attributes"].get("ref", "")
+    pipeline_id = event.data["object_attributes"]["id"]
     sha = event.data["object_attributes"]["sha"]
 
-    if event.data.get("merge_request") and ref.endswith("/merge"):
-        # MR merge pipelines use a synthetic merge commit, so report the source
-        # commit status back to GitHub instead.
-        commit_info = await gl.get_commit(project, sha)
-        sha = commit_info["parent_ids"][1]
+    if event.data.get("merge_request"):
+        # Fetch the pipeline from the API to get the correct ref (which may include /merge suffix)
+        pipeline = await gl.get_pipeline(project, pipeline_id)
+        ref = pipeline.get("ref", "")
+
+        if ref.endswith("/merge"):
+            # MR merge pipelines use a synthetic merge commit, so report the source
+            # commit status back to GitHub instead.
+            commit_info = await gl.get_commit(project, sha)
+            sha = commit_info["parent_ids"][1]
 
     name = gh_check_name
-
     pipeline_url = event.data["object_attributes"]["url"]
 
     await gh.set_check_status(

--- a/src/hubcast/web/gitlab/routes.py
+++ b/src/hubcast/web/gitlab/routes.py
@@ -79,12 +79,11 @@ async def pipeline_status_relay(
             commit_info = await gl.get_commit(project, sha)
             sha = commit_info["parent_ids"][1]
 
-    name = gh_check_name
     pipeline_url = event.data["object_attributes"]["url"]
 
     await gh.set_check_status(
         sha,
-        name,
+        gh_check_name,
         status,
         title="External pipeline run",
         summary=f"[View this pipeline on {urlparse(pipeline_url).netloc}]({pipeline_url})",

--- a/src/hubcast/webhook/token.py
+++ b/src/hubcast/webhook/token.py
@@ -25,7 +25,6 @@ class RoutingToken(BaseModel):
     gh_owner: str
     gh_repo: str
     gh_check: str
-    create_mr: bool
 
     def encode(self, secret: str) -> str:
         """Generate a cryptographically signed JWT token.


### PR DESCRIPTION
Depends on #333 and #332 

Quick fix proposal to allow teams to use `create_mr` without suffixes so they can continue using "required checks" that want the GitLab CI to all have the same names across PRs and branches. I think there's a better long term solution where we could expose each suffix as a config option in the repository config, but I wanted to potentially get this in quick so we can start onboarding folks without breaking their existing workflows and then work up to a better solution if folks want to relay statuses from both merged results and branch runs on MRs.