### PR TITLE
Handle reviews without comments silently

### DIFF
--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -390,6 +390,10 @@ async def respond_pr_comment(
 ) -> None:
     comment = event.data["review"]["body"]
 
+    # reviews without comments (plain approvals or RFC)
+    if not comment:
+        return
+
     if re.search(f"{gh.bot_caller} approve", comment, re.IGNORECASE):
         # sync PR changes to the destination on behalf of the commenter
         # does not handle PR deletions, those will need to be manually cleaned by project maintainers


### PR DESCRIPTION
Plain approvals to a PR were causing issues when respond_pr_comment would try to parse the comment when none existed.