### PR TITLE
User guide clarity

### DIFF
--- a/docs/guide-developer.md
+++ b/docs/guide-developer.md
@@ -67,6 +67,42 @@ Note that you will need to set up two channels: one for the source webhook handl
 smee -u https://smee.io/HASH -t http://localhost:8080/v1/events/src/github
 ```
 
+To set up a test repository, create a repo on GitHub.com and your destination GitLab forge.
+
+Initialize the local repo:
+
+```sh
+mkdir hubcast-test && cd hubcast-test
+git init .
+```
+
+To test CI job status syncing, add a job in `.gitlab-ci.yml`:
+
+```yaml
+build-job:
+  stage: build
+  script:
+    - echo "Hello, $GITLAB_USER_LOGIN!"
+```
+
+Add a minimal configuration to `.github/hubcast.yml`:
+
+```yaml
+Repo:
+  dest_org: example
+  dest_name: hubcast-test
+```
+
+Commit the changes and push to the source repository:
+
+```sh
+git add . && git commit -m "init"
+git remote add gh git@github.com:example/hubcast-test.git
+git push gh main
+```
+
+Hubcast will now sync automatically to the destination!
+
 ## Development Tasks
 
 ### Account Maps
@@ -75,3 +111,5 @@ Account maps are used by Hubcast to link user accounts between Git forges. Hubca
 To write your own account mapper, see the abstract base class in [`src/hubcast/account_map/abc.py`](/src/hubcast/account_map/abc.py) and current implementations in the `account_map` directory.
 
 The basic idea is to define an input (a file, metadata from a webhook) where the initiating user is identified, along a way to link that user's identity to an account on the destination forge.
+
+

--- a/docs/guide-developer.md
+++ b/docs/guide-developer.md
@@ -111,5 +111,3 @@ Account maps are used by Hubcast to link user accounts between Git forges. Hubca
 To write your own account mapper, see the abstract base class in [`src/hubcast/account_map/abc.py`](/src/hubcast/account_map/abc.py) and current implementations in the `account_map` directory.
 
 The basic idea is to define an input (a file, metadata from a webhook) where the initiating user is identified, along a way to link that user's identity to an account on the destination forge.
-
-

--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -4,7 +4,7 @@ This guide covers usage of Hubcast to sync repository state between Git forges.
 
 ## Initialization
 
-If you've set up a local instance of Hubcast or using it for the first time, we recommend setting up a test repository. To create a test repo on GitHub, click [here](https://github.com/new?name=hubcast-test). Next initialize a local repo on your computer.
+If you've set up a local instance of Hubcast or are using it for the first time, we recommend setting up a test repository. To create a test repo on GitHub, click [here](https://github.com/new?name=hubcast-test). Next, initialize a local repo on your computer.
 
 ```sh
 mkdir hubcast-test && cd hubcast-test
@@ -17,7 +17,7 @@ For Hubcast to function properly, the state of both source and destination repos
 
 ## Configuration
 
-Behavior specific to each repository can be configured via the `hubcast.yml` file. Create this file at `.github/hubcast.yml` in your repository:
+Hubcast settings for each repository are defined in the `hubcast.yml` file. Create this file at `.github/hubcast.yml` in your repository:
 
 ```yaml
 Repo:

--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -2,18 +2,7 @@
 
 This guide covers usage of Hubcast to sync repository state between Git forges.
 
-## Initialization
-
-If you've set up a local instance of Hubcast or are using it for the first time, we recommend setting up a test repository. To create a test repo on GitHub, click [here](https://github.com/new?name=hubcast-test). Next, initialize a local repo on your computer.
-
-```sh
-mkdir hubcast-test && cd hubcast-test
-git init .
-```
-
-If you haven't already, create a repository on the destination forge (like GitLab.com).
-
-For Hubcast to function properly, the state of both source and destination repos need to be identical before any syncing can occur.
+First, identify the source and destination repositories Hubcast will be syncing.
 
 ## Configuration
 
@@ -72,23 +61,6 @@ Repo:
 > Also, if you open a PR to edit the Hubcast configuration file, you will not be able to preview the settings change in the PR web view.
 > 
 > This restriction is in place for security purposes.
-
-If you'd like to test the CI job status syncing, add a job in `.gitlab-ci.yml`.
-
-```yaml
-build-job:
-  stage: build
-  script:
-    - echo "Hello, $GITLAB_USER_LOGIN!"
-```
-
-Commit the changes and push to the source repository:
-
-```sh
-git add . && git commit -m "init"
-git remote add gh git@github.com:example/hubcast-test.git
-git push gh main
-```
 
 Hubcast will sync changes via a force push if there has been a local change to the destination repository. To avoid issues, you may wish to disable the default force push branch protection rules on the destination repository.
 

--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -66,8 +66,11 @@ Repo:
 
 > [!TIP]
 > Hubcast will always search for its settings in the HEAD of the source repository's default branch.
+> 
 > This means that Hubcast won't perform any syncing on the initial PR used to add the configuration file. 
+> 
 > Also, if you open a PR to edit the Hubcast configuration file, those settings will propagate upon merging that PR (i.e., you cannot preview the settings change).
+> 
 > This restriction is in place for security purposes.
 
 If you'd like to test the CI job status syncing, add a job in `.gitlab-ci.yml`.

--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -6,7 +6,7 @@ First, identify the source and destination repositories Hubcast will be syncing.
 
 ## Configuration
 
-Hubcast settings for each repository are defined in the `hubcast.yml` file. Create this file at `.github/hubcast.yml` in your repository:
+Hubcast settings for each repository are defined in the `hubcast.yml` file. Create this file at `.github/hubcast.yml` in your GitHub repository:
 
 ```yaml
 Repo:

--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -90,9 +90,7 @@ git remote add gh git@github.com:example/hubcast-test.git
 git push gh main
 ```
 
-To avoid issues with Hubcast syncing:
-- Allow force pushes on the destination repository for all branches.
-- Ensure that the destination does not diverge from the source repository. This is unlikely, but can happen accidentally.
+Hubcast will sync changes via a force push if there has been a local change to the destination repository. To avoid issues, disable force push protection rules on the destination repository.
 
 ## Installation
 

--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -67,9 +67,9 @@ Repo:
 > [!TIP]
 > Hubcast will always search for its settings in the HEAD of the source repository's default branch.
 > 
-> This means that Hubcast won't perform any syncing on the initial PR used to add the configuration file. 
+> This means that Hubcast won't perform syncing on the initial PR used to add the configuration file. 
 > 
-> Also, if you open a PR to edit the Hubcast configuration file, those settings will propagate upon merging that PR (i.e., you cannot preview the settings change).
+> Also, if you open a PR to edit the Hubcast configuration file, you will not be able to preview the settings change in the PR web view.
 > 
 > This restriction is in place for security purposes.
 

--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -64,7 +64,11 @@ Repo:
   dest_name: hubcast-test
 ```
 
-Note: Hubcast will search for these settings in the HEAD of the source repository's default branch.
+> [!TIP]
+> Hubcast will always search for its settings in the HEAD of the source repository's default branch.
+> This means that Hubcast won't perform any syncing on the initial PR used to add the configuration file. 
+> Also, if you open a PR to edit the Hubcast configuration file, those settings will propagate upon merging that PR (i.e., you cannot preview the settings change).
+> This restriction is in place for security purposes.
 
 If you'd like to test the CI job status syncing, add a job in `.gitlab-ci.yml`.
 
@@ -83,7 +87,9 @@ git remote add gh git@github.com:example/hubcast-test.git
 git push gh main
 ```
 
-While unlikely, ensure that your destination repository is never "ahead" of the source repository (i.e., has newer commits); Hubcast will fail to sync in this case.
+To avoid issues with Hubcast syncing:
+- Allow force pushes on the destination repository for all branches.
+- Ensure that the destination does not diverge from the source repository. This is unlikely, but can happen accidentally.
 
 ## Installation
 

--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -75,14 +75,15 @@ build-job:
     - echo "Hello, $GITLAB_USER_LOGIN!"
 ```
 
-To ensure the source and destination repos have the same state, commit the changes and push to the two remotes:
+Commit the changes and push to the source repository:
 
 ```sh
 git add . && git commit -m "init"
 git remote add gh git@github.com:example/hubcast-test.git
-git remote add gl git@gitlab.com:example/hubcast-test.git
-git push gh main && git push gl main
+git push gh main
 ```
+
+While unlikely, ensure that your destination repository is never "ahead" of the source repository (i.e., has newer commits); Hubcast will fail to sync in this case.
 
 ## Installation
 
@@ -130,14 +131,14 @@ Depending on the setup of your Hubcast installation, you can request assistance 
 
 The bot supports the following commands:
 - `@{bot} help` - Display available commands and usage information
-- `@{bot} approve` - Sync this pull request to the destination forge and trigger a new pipeline (requires maintainer permissions)
+- `@{bot} sync` or `approve` - Sync this pull request to the destination forge and trigger a new pipeline (requires maintainer permissions)
 - `@{bot} run pipeline` - Request a new run of the GitLab CI pipeline
 - `@{bot} restart failed jobs` - Restart any failed jobs in the latest CI pipeline
 
 Replace `@{bot}` with your instance's bot user (e.g., `@lc-hubcast`) or use `/hubcast` if no bot user is configured.
 
 #### Approval
-To securely sync commits from external collaborators, approvals require links to a commit hash. You can comment your approval on a PR review:
+To securely sync commits from external collaborators, approvals must be done via commenting on a PR review, ensuring that the approval is linked to a specific commit.
 
 ![A GitHub pull request review; the user has written a comment `@lc-hubcast approve` to sync the user's contributions.](/docs/img/approve-comment.png)
 

--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -90,7 +90,7 @@ git remote add gh git@github.com:example/hubcast-test.git
 git push gh main
 ```
 
-Hubcast will sync changes via a force push if there has been a local change to the destination repository. To avoid issues, disable force push protection rules on the destination repository.
+Hubcast will sync changes via a force push if there has been a local change to the destination repository. To avoid issues, you may wish to disable the default force push branch protection rules on the destination repository.
 
 ## Installation
 

--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -131,7 +131,7 @@ Depending on the setup of your Hubcast installation, you can request assistance 
 
 The bot supports the following commands:
 - `@{bot} help` - Display available commands and usage information
-- `@{bot} sync` or `approve` - Sync this pull request to the destination forge and trigger a new pipeline (requires maintainer permissions)
+- `@{bot} approve` - Sync this pull request to the destination forge and trigger a new pipeline (requires maintainer permissions)
 - `@{bot} run pipeline` - Request a new run of the GitLab CI pipeline
 - `@{bot} restart failed jobs` - Restart any failed jobs in the latest CI pipeline
 

--- a/src/hubcast/web/comments.py
+++ b/src/hubcast/web/comments.py
@@ -2,12 +2,14 @@ def help_message(bot_caller: str) -> str:
     return f"""
 You can interact with me in many ways!
 
+- `{bot_caller} sync` or `approve`: 
+    - Manually sync this PR to the destination repo
+    - Hubcast will perform syncs and run pipelines on behalf of the commenter
+- `{bot_caller} run pipeline`: request a new run of the GitLab CI pipeline
+- `{bot_caller} restart failed jobs`: restart any failed jobs in the most recent pipeline
 - `{bot_caller} help`: see this message
-- `{bot_caller} approve`: sync this pull request with the destination repository and trigger a new pipeline
-- `{bot_caller} run pipeline`: request a new run of the GitLab CI pipeline for any reason
-- `{bot_caller} restart failed jobs`: restart any failed jobs in the latest CI pipeline
 
-If you are an outside contributor to this repository, a maintainer will need to approve and run pipelines on your behalf.
+If you are an outside contributor, a maintainer will need to approve your commits using the [GitHub review comment feature](https://github.com/llnl/hubcast/blob/main/docs/guide-user.md#approval).
 
 For assistance and bug reports, open an issue [here](https://github.com/llnl/hubcast/issues).
 """

--- a/src/hubcast/web/comments.py
+++ b/src/hubcast/web/comments.py
@@ -11,5 +11,7 @@ You can interact with me in many ways!
 
 If you are an outside contributor, a maintainer will need to approve your commits using the [GitHub review comment feature](https://github.com/llnl/hubcast/blob/main/docs/guide-user.md#approval).
 
+A [user guide](https://github.com/llnl/hubcast/blob/main/docs/guide-user.md) is available for additional details on Hubcast's functionality.
+
 For assistance and bug reports, open an issue [here](https://github.com/llnl/hubcast/issues).
 """

--- a/src/hubcast/web/comments.py
+++ b/src/hubcast/web/comments.py
@@ -2,7 +2,7 @@ def help_message(bot_caller: str) -> str:
     return f"""
 You can interact with me in many ways!
 
-- `{bot_caller} sync` or `approve`: 
+- `{bot_caller} approve`: 
     - Manually sync this PR to the destination repo
     - Hubcast will perform syncs and run pipelines on behalf of the commenter
 - `{bot_caller} run pipeline`: request a new run of the GitLab CI pipeline

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -394,7 +394,7 @@ async def respond_pr_comment(
     if not comment:
         return
 
-    if re.search(f"{gh.bot_caller} approve", comment, re.IGNORECASE):
+    if re.search(f"{gh.bot_caller} (approve|sync)", comment, re.IGNORECASE):
         # sync PR changes to the destination on behalf of the commenter
         # does not handle PR deletions, those will need to be manually cleaned by project maintainers
 
@@ -435,12 +435,12 @@ async def respond_comment(
     if re.search(f"{gh.bot_caller} help", comment, re.IGNORECASE):
         response = comments.help_message(gh.bot_caller)
 
-    elif re.search(f"{gh.bot_caller} approve", comment, re.IGNORECASE):
+    elif re.search(f"{gh.bot_caller} (approve|sync)", comment, re.IGNORECASE):
         response = (
-            "To approve the sync of this PR, please use the "
+            "To approve syncing this PR, please use the "
             "[GitHub review comment feature](https://github.com/llnl/hubcast/blob/main/docs/guide-user.md#approval) "
-            "to submit an approval. This ensures the approval is tied to a specific "
-            "commit to avoid unintended syncing of malicious commits."
+            "to submit an approval. This ensures approval is tied to a specific "
+            "commit to avoid the sync of malicious data."
         )
 
     elif re.search(

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -394,7 +394,7 @@ async def respond_pr_comment(
     if not comment:
         return
 
-    if re.search(f"{gh.bot_caller} (approve|sync)", comment, re.IGNORECASE):
+    if re.search(f"{gh.bot_caller} approve", comment, re.IGNORECASE):
         # sync PR changes to the destination on behalf of the commenter
         # does not handle PR deletions, those will need to be manually cleaned by project maintainers
 
@@ -435,7 +435,7 @@ async def respond_comment(
     if re.search(f"{gh.bot_caller} help", comment, re.IGNORECASE):
         response = comments.help_message(gh.bot_caller)
 
-    elif re.search(f"{gh.bot_caller} (approve|sync)", comment, re.IGNORECASE):
+    elif re.search(f"{gh.bot_caller} approve", comment, re.IGNORECASE):
         response = (
             "To approve syncing this PR, please use the "
             "[GitHub review comment feature](https://github.com/llnl/hubcast/blob/main/docs/guide-user.md#approval) "


### PR DESCRIPTION
I removed the confusing piece in the user guide about the destination forge needing to be in the same state as the source, I clarified that it must never be ahead (this is super unlikely but I wanted to be clear).