### PR TITLE
Cache absence of repo config

### DIFF
--- a/src/hubcast/clients/github/client.py
+++ b/src/hubcast/clients/github/client.py
@@ -5,8 +5,6 @@ import aiohttp
 from gidgethub import HTTPException
 from gidgethub import aiohttp as gh_aiohttp
 
-from hubcast.exceptions import HubcastError
-
 from .auth import GitHubAuthenticator
 
 log = logging.getLogger(__name__)
@@ -122,7 +120,7 @@ class GitHubClient:
                 url = f"/repos/{self.repo_owner}/{self.repo_name}/check-runs/{existing_check['id']}"
                 await gh.patch(url, data=payload)
 
-    async def get_repo_config(self) -> str:
+    async def get_repo_config(self) -> str | None:
         gh_token = await self.auth.authenticate_installation(
             self.repo_owner, self.repo_name
         )
@@ -137,11 +135,8 @@ class GitHubClient:
                 return await gh.getitem(url, accept="application/vnd.github.raw")
             except HTTPException as exc:
                 if exc.status_code == 404:
-                    raise HubcastError(
-                        "Repo config file not found at .github/hubcast.yml",
-                        log_level="INFO",
-                        repo=f"{self.repo_owner}/{self.repo_name}",
-                    ) from None
+                    # the repo config was not found: the caller will handle this case
+                    return
                 # all others are unhandled
                 raise
 

--- a/src/hubcast/exceptions.py
+++ b/src/hubcast/exceptions.py
@@ -14,6 +14,8 @@ class HubcastError(Exception):
     def log(self, logger: logging.Logger, **extra_context) -> None:
         """Log this exception with its context and any extra info."""
         level = getattr(logging, self.log_level)
+        # Only include traceback for ERROR level and above
+        exc_info = self.log_level in ("ERROR", "CRITICAL")
         logger.log(
-            level, str(self), extra={**self.context, **extra_context}, exc_info=True
+            level, str(self), extra={**self.context, **extra_context}, exc_info=exc_info
         )

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -1,9 +1,13 @@
+import logging
+
 import yaml
 from cachetools import TTLCache
 
 from hubcast.clients.github import GitHubClient
 from hubcast.exceptions import HubcastError
 from hubcast.repos.config import RepoConfig
+
+log = logging.getLogger(__name__)
 
 # Shared cache for repository configs with 30-minute TTL
 config_cache: TTLCache[str, RepoConfig] = TTLCache(maxsize=1000, ttl=1800)
@@ -26,31 +30,47 @@ async def get_repo_config(
         HubcastError: If config file contains invalid YAML, is missing required keys,
             or has validation errors
     """
-    fetched = False
+    # check cache first unless refresh is requested
     if fullname in config_cache and not refresh:
         config = config_cache[fullname]
-    else:
-        config_str = await gh.get_repo_config()
-
-        try:
-            config_yaml = yaml.safe_load(config_str)
-        except yaml.YAMLError as e:
+        log.info("Repo config retrieved from cache")
+        if config is None:
+            # raise so route handlers can't continue
             raise HubcastError(
-                f"Invalid YAML in repo config for {fullname}: {e}",
+                "Config file not found",
                 log_level="INFO",
-                repo=fullname,
             )
+        return config, False
 
-        try:
-            config = RepoConfig.model_validate(config_yaml)
-        except ValueError as e:
-            raise HubcastError(
-                f"Invalid repo config for {fullname}: {e}",
-                log_level="INFO",
-                repo=fullname,
-            ) from None
+    # cache miss or refresh requested, fetch from GH
+    fetched_config = await gh.get_repo_config()
 
-        config_cache[fullname] = config
-        fetched = True
+    if fetched_config is None:  # 404
+        config_cache[fullname] = None
+        log.info("Cached absence of repo config")
+        # raise so route handlers can't continue
+        raise HubcastError(
+            "Repo config file not found",
+            log_level="INFO",
+        )
 
-    return config, fetched
+    # parse and validate YAML
+    try:
+        config_yaml = yaml.safe_load(fetched_config)
+    except yaml.YAMLError as e:
+        raise HubcastError(
+            f"Invalid YAML in repo config for {fullname}: {e}",
+            log_level="INFO",
+        )
+
+    try:
+        config = RepoConfig.model_validate(config_yaml)
+    except ValueError as e:
+        raise HubcastError(
+            f"Invalid repo config for {fullname}: {e}",
+            log_level="INFO",
+        )
+
+    config_cache[fullname] = config
+    log.info("Repo config fetched from source forge")
+    return config, True

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -10,7 +10,7 @@ from hubcast.repos.config import RepoConfig
 log = logging.getLogger(__name__)
 
 # Shared cache for repository configs with 30-minute TTL
-config_cache: TTLCache[str, RepoConfig] = TTLCache(maxsize=1000, ttl=1800)
+config_cache: TTLCache[str, RepoConfig | None] = TTLCache(maxsize=1000, ttl=1800)
 
 
 async def get_repo_config(


### PR DESCRIPTION
If repo config is not found, cache it as None. As previously implemented, if a push is made to the default branch, Hubcast will invalidate the cache and look the config up again.

Also, added some better logging around the fetching of the repo config and a tiny improvement to logging exceptions.