### PR TITLE
Update pinned aiohttp version

### DIFF
--- a/.github/workflows/requirements/unit-tests.txt
+++ b/.github/workflows/requirements/unit-tests.txt
@@ -1,4 +1,4 @@
-aiohttp==3.13.5
+aiohttp==3.14
 build==1.5.0
 cachetools==7.1.2
 coverage==7.14.0


### PR DESCRIPTION
Dependabot created these alerts but was unable to create a PR because it doesn't support pip freeze style locking?

https://github.com/llnl/hubcast/security/dependabot/16