### PR TITLE
ci: don't build container if previous jobs failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     uses: ./.github/workflows/coverage.yml
 
   container:
-    if: always() && needs.changes.outputs.container == 'true'
+    if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.changes.outputs.container == 'true' }}
     needs: [changes, style, security]
     uses: ./.github/workflows/container.yml
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,7 @@ jobs:
     uses: ./.github/workflows/coverage.yml
 
   container:
-    if: ${{ !contains(needs.*.result, 'failure') && \
-            !contains(needs.*.result, 'cancelled') && \
-            needs.changes.outputs.container == 'true' }}
+    if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.changes.outputs.container == 'true' }}
     needs: [changes, style, security]
     uses: ./.github/workflows/container.yml
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,9 @@ jobs:
     uses: ./.github/workflows/coverage.yml
 
   container:
-    if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.changes.outputs.container == 'true' }}
+    if: ${{ !contains(needs.*.result, 'failure') && \
+            !contains(needs.*.result, 'cancelled') && \
+            needs.changes.outputs.container == 'true' }}
     needs: [changes, style, security]
     uses: ./.github/workflows/container.yml
     permissions:


### PR DESCRIPTION
the container should build if the "needs" jobs are skipped (ie if only the Dockerfile) is changed, but not if there are failures/cancelations