### PR TITLE
Add support for re-running individual jobs

### DIFF
--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -309,6 +309,31 @@ class GitLabClient:
 
             return pipeline.get("web_url")
 
+    async def retry_job(self, gl_fullname: str, job_id: int) -> str:
+        """retries a single job in a GitLab pipeline.
+        Returns:
+            the job's url
+        """
+
+        gl_token = await self.auth.authenticate_user(self.user)
+
+        async with aiohttp.ClientSession() as session:
+            gl = gidgetlab.aiohttp.GitLabAPI(
+                session,
+                requester=self.requester,
+                access_token=gl_token,
+                url=self.instance_url,
+            )
+
+            # temporary fix to support gitlab deployments in sub-paths
+            gl.api_url = f"{self.instance_url}/api/v4/"
+
+            repo_id = urllib.parse.quote_plus(gl_fullname)
+
+            job = await gl.post(f"/projects/{repo_id}/jobs/{job_id}/retry", data={})
+
+            return job.get("web_url")
+
     async def get_commit(self, gl_fullname: str, sha: str) -> dict:
         """Get details for a commit SHA in a project"""
         gl_token = await self.auth.authenticate_user(self.user)

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -787,6 +787,38 @@ async def respond_comment(
         log.info("Skipped comment - no command matched")
 
 
+# job and pipeline checks are created with a details_url pointing
+# at the corresponding GitLab job/pipeline (see job_status_relay and pipeline_status_relay in web/gitlab/routes.py)
+JOB_DETAILS_URL_RE = re.compile(r"/-/jobs/(\d+)/?$")
+PIPELINE_DETAILS_URL_RE = re.compile(r"/-/pipelines/(\d+)/?$")
+
+
+async def _fail_check_from_pipeline_error(
+    gh: GitHubClient,
+    check_name: str,
+    check_run_commit: str,
+    exc: BadRequest,
+) -> None:
+    """Set a failing check status from a GitLab pipeline/job start error."""
+    if exc.status_code in PERMISSION_DENIED_STATUSES:
+        deactivated = DEACTIVATED_ACCOUNT_MARKER in str(exc)
+        message = DEACTIVATED_ACCOUNT_MSG if deactivated else PERMISSION_DENIED_TITLE
+        summary = "" if deactivated else PERMISSION_DENIED_SUMMARY
+    elif exc.status_code == 400:
+        message = PIPELINE_FAILED_MSG
+        summary = str(exc)
+    else:
+        # unknown issues
+        raise exc
+    await gh.set_check_status(
+        check_run_commit,
+        check_name,
+        "failure",
+        title=message,
+        summary=summary,
+    )
+
+
 @router.register("check_run", action="rerequested")
 async def rerun_check(
     event: sansio.Event,
@@ -797,30 +829,25 @@ async def rerun_check(
     **kwargs,
 ) -> None:
     """
-    Handles a user re-running a check run for the latest commit in the branch.
+    Handles a user re-running a check run by retrying the specific GitLab job or pipeline it's attached to.
     See https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=rerequested#check_run.
     """
     src_fullname = event.data["repository"]["full_name"]
-    branch = event.data["check_run"]["check_suite"]["head_branch"]
     check_run_commit = event.data["check_run"]["head_sha"]
+    details_url = event.data["check_run"]["details_url"]
+    update_log_context(
+        check_run_commit=check_run_commit, check_run_id=event.data["check_run"]["id"]
+    )
 
-    # get the latest commit on the branch from GH
-    branch_data = await gh.get_branch(branch)
-    latest_commit = branch_data["commit"]["sha"]
+    job_match = JOB_DETAILS_URL_RE.search(details_url)
+    pipeline_match = PIPELINE_DETAILS_URL_RE.search(details_url)
 
-    # only rerun if this commit is the head of the branch
-    if check_run_commit != latest_commit:
-        log.info(
-            "Skipped check rerun - old commit",
-            extra={
-                "branch": branch,
-                "check_run_commit": check_run_commit,
-                "latest_commit": latest_commit,
-            },
+    if not any((job_match, pipeline_match)):
+        log.warning(
+            "Skipped check rerun due to unrecognized check type",
         )
         return
 
-    # get the GL repo info and run the pipeline
     try:
         repo_config, _ = await get_repo_config(gh, src_fullname)
     except RepoConfigError as exc:
@@ -829,33 +856,25 @@ async def rerun_check(
 
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
 
-    try:
-        await gl.run_pipeline(dest_fullname, branch)
-    except BadRequest as exc:
-        if exc.status_code in PERMISSION_DENIED_STATUSES:
-            deactivated = DEACTIVATED_ACCOUNT_MARKER in str(exc)
-            message = (
-                DEACTIVATED_ACCOUNT_MSG if deactivated else PERMISSION_DENIED_TITLE
+    if job_match:
+        job_id = int(job_match.group(1))
+        update_log_context(job_id=job_id)
+        try:
+            await gl.retry_job(dest_fullname, job_id)
+        except BadRequest as exc:
+            await _fail_check_from_pipeline_error(
+                gh, repo_config.check_name, check_run_commit, exc
             )
-            summary = "" if deactivated else PERMISSION_DENIED_SUMMARY
-        elif exc.status_code == 400:
-            message = PIPELINE_FAILED_MSG
-            summary = str(exc)
-        else:
-            raise
-        await gh.set_check_status(
-            check_run_commit,
-            repo_config.check_name,
-            "failure",
-            title=message,
-            summary=summary,
-        )
-        return
-
-    log.info(
-        "Rerun check requested for branch",
-        extra={
-            "branch": branch,
-            "check_run_commit": check_run_commit,
-        },
-    )
+            return
+        log.info("Retried job for check run")
+    elif pipeline_match:
+        pipeline_id = int(pipeline_match.group(1))
+        update_log_context(pipeline_id=pipeline_id)
+        try:
+            await gl.retry_pipeline_jobs(dest_fullname, pipeline_id)
+        except BadRequest as exc:
+            await _fail_check_from_pipeline_error(
+                gh, repo_config.check_name, check_run_commit, exc
+            )
+            return
+        log.info("Retried failed jobs for check run")

--- a/tests/test_github_routes.py
+++ b/tests/test_github_routes.py
@@ -1603,7 +1603,9 @@ async def test_rerun_check_pipeline_retry_other_error_raises(
 ):
     """Unrecognized pipeline retry failures should propagate."""
 
-    mock_gl.retry_pipeline_jobs = AsyncMock(side_effect=BadRequest(HTTPStatus(500), "oops"))
+    mock_gl.retry_pipeline_jobs = AsyncMock(
+        side_effect=BadRequest(HTTPStatus(500), "oops")
+    )
 
     with pytest.raises(BadRequest):
         await rerun_check(

--- a/tests/test_github_routes.py
+++ b/tests/test_github_routes.py
@@ -182,13 +182,15 @@ def mock_pr_data_for_comment():
 
 @pytest.fixture
 def mock_check_run_event():
-    """Mocked check run rerequested."""
+    """Mocked check run rerequested, tracking a GitLab pipeline."""
     event = Mock()
     event.data = {
         "repository": {"full_name": "owner/repo"},
         "check_run": {
+            "id": 999,
             "check_suite": {"head_branch": "main"},
             "head_sha": "check-run-sha-123",
+            "details_url": "https://gitlab.example.com/owner/repo/-/pipelines/456",
         },
     }
     return event
@@ -1443,35 +1445,62 @@ async def test_respond_comment_restart_jobs_other_error_raises(
 
 
 @pytest.mark.asyncio
-async def test_check_rerun_skip_old_commit(
+async def test_rerun_check_pipeline_retry(
     mock_check_run_event, mock_gh, mock_gl, mock_repligit_ops, caplog
 ):
-    """Check rerun should be skipped if the latest commit on the branch does not equal the check run commit."""
-
-    # the branch's latest commit is different from the check run's head_sha
-    mock_gh.get_branch.return_value = {"commit": {"sha": "latest-sha-456"}}
+    """A rerequest on a pipeline-tracking check should retry that pipeline's failed jobs."""
 
     await rerun_check(
         event=mock_check_run_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
     )
 
-    assert "Skipped check rerun - old commit" in caplog.text
+    mock_gl.retry_pipeline_jobs.assert_awaited_once_with("owner/repo", 456)
+    mock_gl.retry_job.assert_not_called()
+    assert "Retried failed jobs for check run" in caplog.text
 
 
 @pytest.mark.asyncio
-async def test_check_rerun_requested(
+async def test_rerun_check_job_retry(
     mock_check_run_event, mock_gh, mock_gl, mock_repligit_ops, caplog
 ):
-    """Check rerun should be requested if all conditions are met."""
+    """A rerequest on a job-tracking check should retry just that job."""
 
-    # latest commit on the branch matches the check run head_sha
-    mock_gh.get_branch.return_value = {"commit": {"sha": "check-run-sha-123"}}
+    mock_check_run_event.data["check_run"]["details_url"] = (
+        "https://gitlab.example.com/owner/repo/-/jobs/789"
+    )
 
     await rerun_check(
         event=mock_check_run_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
     )
 
-    assert "Rerun check requested for branch" in caplog.text
+    mock_gl.retry_job.assert_awaited_once_with("owner/repo", 789)
+    mock_gl.retry_pipeline_jobs.assert_not_called()
+    assert "Retried job for check run" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "details_url",
+    [
+        "",
+        "https://hubcast.example.com",
+        "https://gitlab.example.com/owner/repo/-/pipelines/not-a-number",
+    ],
+)
+async def test_rerun_check_unrecognized_check_skipped(
+    details_url, mock_check_run_event, mock_gh, mock_gl, mock_repligit_ops, caplog
+):
+    """A check whose details_url doesn't match a known job/pipeline shape should be skipped, not retried."""
+
+    mock_check_run_event.data["check_run"]["details_url"] = details_url
+
+    await rerun_check(
+        event=mock_check_run_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
+    )
+
+    mock_gl.retry_job.assert_not_called()
+    mock_gl.retry_pipeline_jobs.assert_not_called()
+    assert "Skipped check rerun due to unrecognized check type" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1480,7 +1509,6 @@ async def test_rerun_check_config_error_sets_error_check(
 ):
     """An invalid repo config should be reported as a failed hubcast-error check."""
 
-    mock_gh.get_branch.return_value = {"commit": {"sha": "check-run-sha-123"}}
     mock_repligit_ops["get_repo_config"].side_effect = repo_config_error()
 
     await rerun_check(
@@ -1494,7 +1522,8 @@ async def test_rerun_check_config_error_sets_error_check(
         title="config title",
         summary="config summary",
     )
-    mock_gl.run_pipeline.assert_not_called()
+    mock_gl.retry_pipeline_jobs.assert_not_called()
+    mock_gl.retry_job.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1518,7 +1547,7 @@ async def test_rerun_check_config_error_sets_error_check(
         ),
     ],
 )
-async def test_rerun_check_pipeline_errors(
+async def test_rerun_check_pipeline_retry_errors(
     error,
     expected_title,
     expected_summary,
@@ -1527,10 +1556,9 @@ async def test_rerun_check_pipeline_errors(
     mock_gl,
     mock_repligit_ops,
 ):
-    """Pipeline start failures during a check rerun should fail the check with details."""
+    """Pipeline retry failures during a check rerun should fail the check with details."""
 
-    mock_gh.get_branch.return_value = {"commit": {"sha": "check-run-sha-123"}}
-    mock_gl.run_pipeline = AsyncMock(side_effect=error)
+    mock_gl.retry_pipeline_jobs = AsyncMock(side_effect=error)
 
     await rerun_check(
         event=mock_check_run_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
@@ -1546,13 +1574,36 @@ async def test_rerun_check_pipeline_errors(
 
 
 @pytest.mark.asyncio
-async def test_rerun_check_pipeline_other_error_raises(
+async def test_rerun_check_job_retry_permission_denied(
     mock_check_run_event, mock_gh, mock_gl, mock_repligit_ops
 ):
-    """Unrecognized pipeline start failures should propagate."""
+    """Job retry failures during a check rerun should fail the check the same way pipeline retries do."""
 
-    mock_gh.get_branch.return_value = {"commit": {"sha": "check-run-sha-123"}}
-    mock_gl.run_pipeline = AsyncMock(side_effect=BadRequest(HTTPStatus(500), "oops"))
+    mock_check_run_event.data["check_run"]["details_url"] = (
+        "https://gitlab.example.com/owner/repo/-/jobs/789"
+    )
+    mock_gl.retry_job = AsyncMock(side_effect=BadRequest(HTTPStatus(403), "forbidden"))
+
+    await rerun_check(
+        event=mock_check_run_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user"
+    )
+
+    mock_gh.set_check_status.assert_awaited_once_with(
+        "check-run-sha-123",
+        "hubcast",
+        "failure",
+        title=PERMISSION_DENIED_TITLE,
+        summary=PERMISSION_DENIED_SUMMARY,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rerun_check_pipeline_retry_other_error_raises(
+    mock_check_run_event, mock_gh, mock_gl, mock_repligit_ops
+):
+    """Unrecognized pipeline retry failures should propagate."""
+
+    mock_gl.retry_pipeline_jobs = AsyncMock(side_effect=BadRequest(HTTPStatus(500), "oops"))
 
     with pytest.raises(BadRequest):
         await rerun_check(


### PR DESCRIPTION
GitHub's check run restart feature will now work for checks linked to
individual jobs.

This PR also modifies how we restart pipelines:

instead of creating a new pipeline under the latest commit on the
branch, we now retry any failed jobs within the pipeline linked to the
check. this cuts down on API calls and avoids issues when both jobs and
pipeline retries are requested.

now, the only path to create a new pipeline is via the bot interface