### PR TITLE
Trigger PR handler when draft PRs are made ready for review

### DIFF
--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -478,6 +478,7 @@ async def sync_pr(
 @router.register("pull_request", action="opened")
 @router.register("pull_request", action="reopened")
 @router.register("pull_request", action="synchronize")
+@router.register("pull_request", action="ready_for_review")
 async def sync_pr_event(
     event: sansio.Event,
     gh: GitHubClient,

--- a/tests/test_github_routes.py
+++ b/tests/test_github_routes.py
@@ -682,16 +682,6 @@ async def test_sync_pr_ready_for_review(
     )
 
 
-def test_sync_pr_event_registered_for_ready_for_review():
-    """The router must dispatch pull_request/ready_for_review to sync_pr_event."""
-    from hubcast.web.github.routes import router
-
-    callbacks = router._deep_routes["pull_request"]["action"].get(
-        "ready_for_review", []
-    )
-    assert sync_pr_event in callbacks
-
-
 @pytest.mark.asyncio
 async def test_sync_pr_creates_mr_when_configured(
     mock_pr_event, mock_gh, mock_gl, mock_repligit_ops, caplog

--- a/tests/test_github_routes.py
+++ b/tests/test_github_routes.py
@@ -663,6 +663,36 @@ async def test_sync_pr_opened_uses_head_sha(
 
 
 @pytest.mark.asyncio
+async def test_sync_pr_ready_for_review(
+    mock_pr_event, mock_gh, mock_gl, mock_repligit_ops, caplog
+):
+    """Marking a draft PR ready for review should trigger a sync using the head sha."""
+
+    mock_pr_event.data["action"] = "ready_for_review"
+    mock_pr_event.data["pull_request"]["head"]["sha"] = "head-sha-456"
+
+    mock_repligit_ops["ls_remote"].return_value = {"refs/heads/main": "old-sha"}
+
+    await sync_pr_event(event=mock_pr_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
+
+    assert "Synced PR" in caplog.text
+    assert any(
+        hasattr(record, "want_sha") and record.want_sha == "head-sha-456"
+        for record in caplog.records
+    )
+
+
+def test_sync_pr_event_registered_for_ready_for_review():
+    """The router must dispatch pull_request/ready_for_review to sync_pr_event."""
+    from hubcast.web.github.routes import router
+
+    callbacks = router._deep_routes["pull_request"]["action"].get(
+        "ready_for_review", []
+    )
+    assert sync_pr_event in callbacks
+
+
+@pytest.mark.asyncio
 async def test_sync_pr_creates_mr_when_configured(
     mock_pr_event, mock_gh, mock_gl, mock_repligit_ops, caplog
 ):

--- a/tests/test_github_routes.py
+++ b/tests/test_github_routes.py
@@ -642,33 +642,13 @@ async def test_sync_pr_synced_internal(
 
 
 @pytest.mark.asyncio
-async def test_sync_pr_opened_uses_head_sha(
-    mock_pr_event, mock_gh, mock_gl, mock_repligit_ops, caplog
+@pytest.mark.parametrize("action", ["opened", "reopened", "ready_for_review"])
+async def test_sync_pr_uses_head_sha(
+    action, mock_pr_event, mock_gh, mock_gl, mock_repligit_ops, caplog
 ):
-    """PR opened event should use head sha instead of after field."""
+    """PR sync events other than synchronize should use head sha instead of the after field."""
 
-    # Change action to "opened" instead of "synchronize"
-    mock_pr_event.data["action"] = "opened"
-    mock_pr_event.data["pull_request"]["head"]["sha"] = "head-sha-456"
-
-    mock_repligit_ops["ls_remote"].return_value = {"refs/heads/main": "old-sha"}
-
-    await sync_pr_event(event=mock_pr_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
-
-    assert "Synced PR" in caplog.text
-    assert any(
-        hasattr(record, "want_sha") and record.want_sha == "head-sha-456"
-        for record in caplog.records
-    )
-
-
-@pytest.mark.asyncio
-async def test_sync_pr_ready_for_review(
-    mock_pr_event, mock_gh, mock_gl, mock_repligit_ops, caplog
-):
-    """Marking a draft PR ready for review should trigger a sync using the head sha."""
-
-    mock_pr_event.data["action"] = "ready_for_review"
+    mock_pr_event.data["action"] = action
     mock_pr_event.data["pull_request"]["head"]["sha"] = "head-sha-456"
 
     mock_repligit_ops["ls_remote"].return_value = {"refs/heads/main": "old-sha"}


### PR DESCRIPTION
Originally found by the Radiuss Team. We weren't catching when PRs changed status from draft to ready_for_review in the case that syncing draft PRs is disabled this meant that folks had to manually approve a PR or push a commit once it was ready for review.