### PR TITLE
Fix exception on push events with null head_commit

### DIFF
--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -115,7 +115,8 @@ async def sync_branch(
 
     dest_fullname = f"{repo_config.dest_org}/{repo_config.dest_name}"
     dest_remote_url = f"{gl.instance_url}/{dest_fullname}.git"
-    commit_msg = event.data.get("head_commit", {}).get("message", "")
+    head_commit = event.data.get("head_commit")
+    commit_msg = head_commit["message"] if head_commit else ""
 
     # only set/update webhook on default branch pushes when config cache was bypassed (refresh or initial fetch)
     # and if the config file itself was changed (config_changed above)


### PR DESCRIPTION
When decoding the json payload it's possible for `event["data"]["head_commit"] = None` but the default value is only used by get when the key is completely absent. So previously we'd forwarded on None and then failed with a key lookup against a None object. 