### PR TITLE
improve gitlab url subpath handling

### DIFF
--- a/.github/workflows/requirements/unit-tests.txt
+++ b/.github/workflows/requirements/unit-tests.txt
@@ -3,7 +3,7 @@ build==1.5.0
 cachetools==7.1.2
 coverage==7.15.2
 gidgethub==5.4.0
-gidgetlab==2.1.1
+gidgetlab==2.1.2
 hatchling==1.31.0
 pytest-asyncio==1.3.0
 pytest-mock==3.15.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "aiojobs",
     "cachetools",
     "gidgethub",
-    "gidgetlab",
+    "gidgetlab>=2.1.2",
     "pydantic",
     "pydantic-settings",
     "pyjwt",

--- a/spack/repos/spack_repo/hubcast/packages/py_hubcast/package.py
+++ b/spack/repos/spack_repo/hubcast/packages/py_hubcast/package.py
@@ -27,7 +27,7 @@ class PyHubcast(PythonPackage):
     depends_on("py-aiojobs", type=("build", "run"))
     depends_on("py-pyjwt", type=("build", "run"))
     depends_on("py-gidgethub", type=("build", "run"))
-    depends_on("py-gidgetlab+aiohttp", type=("build", "run"))
+    depends_on("py-gidgetlab@2.1.2:+aiohttp", type=("build", "run"))
     depends_on("py-repligit", type=("build", "run"))
     depends_on("py-pyyaml", type=("build", "run"))
     depends_on("py-pydantic", type=("build", "run"))

--- a/src/hubcast/clients/gitlab/auth.py
+++ b/src/hubcast/clients/gitlab/auth.py
@@ -65,9 +65,6 @@ class GitLabAuthenticator:
                     url=self.instance_url,
                 )
 
-                # temporary fix to support gitlab deployments in sub-paths
-                gl.api_url = f"{self.instance_url}/api/v4/"
-
                 url = f"/users/{user_id}/impersonation_tokens"
                 expires_day, expires_timestamp = self._date_after_days(expire_days)
 
@@ -98,9 +95,6 @@ class GitLabAuthenticator:
                 access_token=self.admin_token,
                 url=self.instance_url,
             )
-
-            # temporary fix to support gitlab deployments in sub-paths
-            gl.api_url = f"{self.instance_url}/api/v4/"
 
             res = await gl.getitem(f"/users?username={username}")
             if not res:

--- a/src/hubcast/clients/gitlab/client.py
+++ b/src/hubcast/clients/gitlab/client.py
@@ -80,9 +80,6 @@ class GitLabClient:
                 url=self.instance_url,
             )
 
-            # temporary fix to support gitlab deployments in sub-paths
-            gl.api_url = f"{self.instance_url}/api/v4/"
-
             repo_id = urllib.parse.quote_plus(gl_fullname)
             filters = (
                 f"source_branch={src_branch}&target_branch={target_branch}&state=opened"
@@ -116,9 +113,6 @@ class GitLabClient:
                 access_token=gl_token,
                 url=self.instance_url,
             )
-
-            # temporary fix to support gitlab deployments in sub-paths
-            gl.api_url = f"{self.instance_url}/api/v4/"
 
             repo_id = urllib.parse.quote_plus(gl_fullname)
 
@@ -174,9 +168,6 @@ class GitLabClient:
                 url=self.instance_url,
             )
 
-            # temporary fix to support gitlab deployments in sub-paths
-            gl.api_url = f"{self.instance_url}/api/v4/"
-
             repo_id = urllib.parse.quote_plus(gl_fullname)
             url = f"/projects/{repo_id}/hooks"
             try:
@@ -222,9 +213,6 @@ class GitLabClient:
                 url=self.instance_url,
             )
 
-            # temporary fix to support gitlab deployments in sub-paths
-            gl.api_url = f"{self.instance_url}/api/v4/"
-
             repo_id = urllib.parse.quote_plus(gl_fullname)
 
             return await gl.getitem(f"/projects/{repo_id}/pipelines/{pipeline_id}")
@@ -244,9 +232,6 @@ class GitLabClient:
                 access_token=gl_token,
                 url=self.instance_url,
             )
-
-            # temporary fix to support gitlab deployments in sub-paths
-            gl.api_url = f"{self.instance_url}/api/v4/"
 
             repo_id = urllib.parse.quote_plus(gl_fullname)
 
@@ -272,9 +257,6 @@ class GitLabClient:
                 url=self.instance_url,
             )
 
-            # temporary fix to support gitlab deployments in sub-paths
-            gl.api_url = f"{self.instance_url}/api/v4/"
-
             repo_id = urllib.parse.quote_plus(gl_fullname)
 
             pipeline = await gl.post(f"/projects/{repo_id}/pipeline?ref={ref}", data={})
@@ -297,9 +279,6 @@ class GitLabClient:
                 access_token=gl_token,
                 url=self.instance_url,
             )
-
-            # temporary fix to support gitlab deployments in sub-paths
-            gl.api_url = f"{self.instance_url}/api/v4/"
 
             repo_id = urllib.parse.quote_plus(gl_fullname)
 
@@ -325,9 +304,6 @@ class GitLabClient:
                 url=self.instance_url,
             )
 
-            # temporary fix to support gitlab deployments in sub-paths
-            gl.api_url = f"{self.instance_url}/api/v4/"
-
             repo_id = urllib.parse.quote_plus(gl_fullname)
 
             job = await gl.post(f"/projects/{repo_id}/jobs/{job_id}/retry", data={})
@@ -345,9 +321,6 @@ class GitLabClient:
                 access_token=gl_token,
                 url=self.instance_url,
             )
-
-            # temporary fix to support gitlab deployments in sub-paths
-            gl.api_url = f"{self.instance_url}/api/v4/"
 
             repo_id = urllib.parse.quote_plus(gl_fullname)
 


### PR DESCRIPTION
gidgetlab previously didn't support gitlab deployed in subpaths so we needed to manually override api_url. 

@alecbcs contributed a [fix](https://gitlab.com/beenje/gidgetlab/-/merge_requests/20) that is in gidgetlab 2.1.2