### PR TITLE
fix: python-ldap coverage test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,10 @@ jobs:
             pyproject.toml
             .github/workflows/requirements/unit-tests.txt
 
+      - name: Install system dependencies for LDAP
+        run: |
+          sudo apt-get install -y build-essential ldap-utils libldap2-dev libsasl2-dev
+
       - name: Install Python dependencies
         run: |
           pip install .

--- a/.github/workflows/requirements/unit-tests.txt
+++ b/.github/workflows/requirements/unit-tests.txt
@@ -8,4 +8,4 @@ hatchling==1.31.0
 pytest-asyncio==1.3.0
 pytest-mock==3.15.1
 pytest==9.1.1
-python-ldap==3.4.5
+python-ldap==3.4.7


### PR DESCRIPTION
the check-coverage check was not installing python-ldap's system dependencies, leading to failures in https://github.com/llnl/hubcast/pull/389