### PR TITLE
Fix hubcast-error when no config change due to cache timeout

### DIFF
--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -106,7 +106,7 @@ async def sync_branch(
     is_default_branch = sync_ref == f"refs/heads/{default_branch}"
     config_changed = gh.repo_config_path in changed_files_from_push(event.data)
     try:
-        repo_config, fetched = await get_repo_config(
+        repo_config = await get_repo_config(
             gh, src_fullname, refresh=is_default_branch and config_changed
         )
     except RepoConfigError as exc:
@@ -118,11 +118,12 @@ async def sync_branch(
     head_commit = event.data.get("head_commit")
     commit_msg = head_commit["message"] if head_commit else ""
 
-    # only set/update webhook on default branch pushes when config cache was bypassed (refresh or initial fetch)
-    # and if the config file itself was changed (config_changed above)
-    # we want to give maintainers the option to force-set the webhook; an empty commit won't result in a cache miss
-    # if the commit message contains [hubcast config], we'll set the webhook
-    if is_default_branch and (fetched or "[hubcast config]" in commit_msg):
+    # only set/update webhook on default branch pushes when the push actually
+    # touched the config file (config_changed above); this avoids spurious
+    # permission errors when the config merely aged out of the cache
+    # we also give maintainers the option to force-set the webhook: if the
+    # commit message contains [hubcast config], we'll set the webhook
+    if is_default_branch and (config_changed or "[hubcast config]" in commit_msg):
         # setup callback webhook on GitLab
         try:
             await gl.set_webhook(
@@ -252,7 +253,7 @@ async def remove_branch(
     src_fullname = event.data["repository"]["full_name"]
     sync_ref = event.data["ref"]
 
-    repo_config, _ = await get_repo_config(gh, src_fullname)
+    repo_config = await get_repo_config(gh, src_fullname)
 
     dest_fullname = repo_config.dest_fullname
     dest_remote_url = f"{gl.instance_url}/{dest_fullname}.git"
@@ -353,7 +354,7 @@ async def sync_pr(
 
     # get the repository configuration from .github/hubcast.yml
     try:
-        repo_config, _ = await get_repo_config(gh, base_fullname)
+        repo_config = await get_repo_config(gh, base_fullname)
     except RepoConfigError as exc:
         await report_config_error(gh, want_sha, exc)
         return
@@ -523,7 +524,7 @@ async def remove_pr(
     base_fullname = pull_request["base"]["repo"]["full_name"]
 
     # get the repository configuration from .github/hubcast.yml
-    repo_config, _ = await get_repo_config(gh, base_fullname)
+    repo_config = await get_repo_config(gh, base_fullname)
 
     if not repo_config.delete_closed:
         log.info("Skipped PR branch removal - delete_closed disabled")
@@ -693,7 +694,7 @@ async def respond_comment(
         update_log_context(branch=branch)
 
         # get the gitlab repo information and run the pipeline
-        repo_config, _ = await get_repo_config(gh, base_fullname)
+        repo_config = await get_repo_config(gh, base_fullname)
         dest_fullname = repo_config.dest_fullname
 
         try:
@@ -742,7 +743,7 @@ async def respond_comment(
         update_log_context(branch=branch)
 
         # get the gitlab repo information and run the pipeline
-        repo_config, _ = await get_repo_config(gh, base_fullname)
+        repo_config = await get_repo_config(gh, base_fullname)
         dest_fullname = repo_config.dest_fullname
 
         try:
@@ -851,7 +852,7 @@ async def rerun_check(
         return
 
     try:
-        repo_config, _ = await get_repo_config(gh, src_fullname)
+        repo_config = await get_repo_config(gh, src_fullname)
     except RepoConfigError as exc:
         await report_config_error(gh, check_run_commit, exc)
         return

--- a/src/hubcast/web/github/utils.py
+++ b/src/hubcast/web/github/utils.py
@@ -30,7 +30,7 @@ def changed_files_from_push(payload: dict[str, Any]) -> set[str]:
 
 async def get_repo_config(
     gh: GitHubClient, fullname: str, refresh: bool = False
-) -> tuple[RepoConfig, bool]:
+) -> RepoConfig:
     """Get repository configuration from cache or fetch from GitHub.
 
     Args:
@@ -39,7 +39,7 @@ async def get_repo_config(
         refresh: Whether to force refresh from GitHub
 
     Returns:
-        Tuple of (RepoConfig instance, whether it was freshly fetched)
+        RepoConfig instance
 
     Raises:
         HubcastError: If config file contains invalid YAML, is missing required keys,
@@ -54,7 +54,7 @@ async def get_repo_config(
             # we don't want to raise this as a RepoConfigError because telling users
             # about the absence of the config will create noise and confusion
             raise HubcastError("Repo config file not found", log_level="INFO")
-        return config, False
+        return config
 
     # cache miss or refresh requested, fetch from GH
     fetched_config = await gh.get_repo_config()
@@ -88,4 +88,4 @@ async def get_repo_config(
 
     config_cache[fullname] = config
     log.info("Repo config fetched from source forge")
-    return config, True
+    return config

--- a/tests/test_github_routes.py
+++ b/tests/test_github_routes.py
@@ -228,7 +228,6 @@ def mock_repligit_ops():
         patch("hubcast.web.github.routes.fetch_pack") as mock_fetch,
         patch("hubcast.web.github.routes.send_pack") as mock_send,
     ):
-        # get_repo_config returns a tuple (config, fetched)
         default_config = Mock(
             dest_org="owner",
             dest_name="repo",
@@ -239,7 +238,7 @@ def mock_repligit_ops():
             check_name="hubcast",
             check_types=["pipeline"],
         )
-        mock_get_config.return_value = (default_config, True)
+        mock_get_config.return_value = default_config
 
         mock_ls.return_value = {"refs/heads/main": "old-sha-456"}
 
@@ -428,21 +427,21 @@ async def test_sync_branch_config_refresh(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "ref,fetched,commit_msg,webhook_expected",
+    "ref,modified,commit_msg,webhook_expected",
     [
-        # config was (re)fetched on a default branch push
-        ("refs/heads/main", True, "update app", True),
-        # cached config, no marker: nothing to do
-        ("refs/heads/main", False, "update app", False),
+        # config file changed on a default branch push
+        ("refs/heads/main", [".github/hubcast.yml"], "update config", True),
+        # config file untouched, no marker: nothing to do
+        ("refs/heads/main", ["src/app.py"], "update app", False),
         # manual trigger via commit message marker
-        ("refs/heads/main", False, "empty commit [hubcast config]", True),
+        ("refs/heads/main", ["src/app.py"], "empty commit [hubcast config]", True),
         # never set webhooks from non-default branches
-        ("refs/heads/feature", True, "update app", False),
+        ("refs/heads/feature", [".github/hubcast.yml"], "update config", False),
     ],
 )
 async def test_sync_branch_webhook_gating(
     ref,
-    fetched,
+    modified,
     commit_msg,
     webhook_expected,
     mock_push_event,
@@ -450,12 +449,13 @@ async def test_sync_branch_webhook_gating(
     mock_gl,
     mock_repligit_ops,
 ):
-    """Webhook should only be set on default branch pushes with a config fetch or marker."""
+    """Webhook should only be set on default branch pushes touching the config file or with a marker."""
 
     mock_push_event.data["ref"] = ref
     mock_push_event.data["head_commit"]["message"] = commit_msg
-    config, _ = mock_repligit_ops["get_repo_config"].return_value
-    mock_repligit_ops["get_repo_config"].return_value = (config, fetched)
+    mock_push_event.data["commits"] = [
+        {"added": [], "modified": modified, "removed": []}
+    ]
 
     await sync_branch(event=mock_push_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
 
@@ -471,6 +471,10 @@ async def test_sync_branch_webhook_permission_denied(
 ):
     """A non-maintainer pushing config changes should get a failed check explaining the fix."""
 
+    # the push touches the config file, so the webhook update is attempted
+    mock_push_event.data["commits"] = [
+        {"added": [], "modified": [".github/hubcast.yml"], "removed": []}
+    ]
     mock_gl.set_webhook.side_effect = WebhookPermissionError("not a maintainer")
 
     await sync_branch(event=mock_push_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
@@ -492,6 +496,10 @@ async def test_sync_branch_webhook_internal_error(
 ):
     """A broken hubcast credential should be reported as an internal error."""
 
+    # the push touches the config file, so the webhook update is attempted
+    mock_push_event.data["commits"] = [
+        {"added": [], "modified": [".github/hubcast.yml"], "removed": []}
+    ]
     mock_gl.set_webhook.side_effect = HubcastError("GitLab rejected hubcast's token")
 
     await sync_branch(event=mock_push_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
@@ -566,14 +574,11 @@ async def test_sync_pr_skip_draft(
     """PR sync should be skipped for draft PRs (when sync_drafts is False)."""
 
     mock_pr_event.data["pull_request"]["draft"] = True
-    mock_repligit_ops["get_repo_config"].return_value = (
-        Mock(
-            sync_drafts=False,
-            dest_org="owner",
-            dest_name="repo",
-            dest_fullname="owner/repo",
-        ),
-        True,
+    mock_repligit_ops["get_repo_config"].return_value = Mock(
+        sync_drafts=False,
+        dest_org="owner",
+        dest_name="repo",
+        dest_fullname="owner/repo",
     )
 
     await sync_pr_event(event=mock_pr_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
@@ -588,15 +593,12 @@ async def test_sync_pr_skip_draft_without_message(
     """Draft PR skips should not set a check status when sync_drafts_msg is False."""
 
     mock_pr_event.data["pull_request"]["draft"] = True
-    mock_repligit_ops["get_repo_config"].return_value = (
-        Mock(
-            sync_drafts=False,
-            sync_drafts_msg=False,
-            dest_org="owner",
-            dest_name="repo",
-            dest_fullname="owner/repo",
-        ),
-        True,
+    mock_repligit_ops["get_repo_config"].return_value = Mock(
+        sync_drafts=False,
+        sync_drafts_msg=False,
+        dest_org="owner",
+        dest_name="repo",
+        dest_fullname="owner/repo",
     )
 
     await sync_pr_event(event=mock_pr_event, gh=mock_gh, gl=mock_gl, gl_user="gl-user")
@@ -682,14 +684,11 @@ async def test_sync_pr_creates_mr_when_configured(
     )
 
     # Configure repo to create MRs
-    mock_repligit_ops["get_repo_config"].return_value = (
-        Mock(
-            dest_org="owner",
-            dest_name="repo",
-            dest_fullname="owner/repo",
-            create_mr=True,
-        ),
-        True,
+    mock_repligit_ops["get_repo_config"].return_value = Mock(
+        dest_org="owner",
+        dest_name="repo",
+        dest_fullname="owner/repo",
+        create_mr=True,
     )
 
     mock_repligit_ops["ls_remote"].return_value = {"refs/heads/main": "old-sha"}
@@ -710,14 +709,11 @@ async def test_sync_pr_skips_mr_when_already_exists(
     """Should skip MR creation when MR already exists."""
 
     # Configure repo to create MRs
-    mock_repligit_ops["get_repo_config"].return_value = (
-        Mock(
-            dest_org="owner",
-            dest_name="repo",
-            dest_fullname="owner/repo",
-            create_mr=True,
-        ),
-        True,
+    mock_repligit_ops["get_repo_config"].return_value = Mock(
+        dest_org="owner",
+        dest_name="repo",
+        dest_fullname="owner/repo",
+        create_mr=True,
     )
 
     mock_repligit_ops["ls_remote"].return_value = {"refs/heads/main": "old-sha"}
@@ -915,14 +911,11 @@ async def test_remove_pr_skip_delete_closed_false(
     """PR branch removal should be skipped when delete_closed=False (PR 280)."""
 
     # Configure repo to NOT delete branches on PR close
-    mock_repligit_ops["get_repo_config"].return_value = (
-        Mock(
-            delete_closed=False,
-            dest_org="owner",
-            dest_name="repo",
-            dest_fullname="owner/repo",
-        ),
-        True,
+    mock_repligit_ops["get_repo_config"].return_value = Mock(
+        delete_closed=False,
+        dest_org="owner",
+        dest_name="repo",
+        dest_fullname="owner/repo",
     )
 
     await remove_pr(

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -124,14 +124,12 @@ async def test_get_repo_config_uses_cache(mock_github_client):
     """Should use cached config on second call."""
 
     # first call -- fetches from client
-    config1, fetched1 = await get_repo_config(mock_github_client, "owner/repo")
+    config1 = await get_repo_config(mock_github_client, "owner/repo")
 
     # second call -- uses cache
-    config2, fetched2 = await get_repo_config(mock_github_client, "owner/repo")
+    config2 = await get_repo_config(mock_github_client, "owner/repo")
 
     assert config1.dest_org == config2.dest_org
-    assert fetched1 is True  # first call should fetch from GitHub
-    assert fetched2 is False  # second call should use cache
     mock_github_client.get_repo_config.assert_called_once()  # should only be called once
 
 
@@ -140,7 +138,7 @@ async def test_get_repo_config_refreshes(mock_github_client):
     """Should refresh cache when requested."""
 
     # first call
-    config1, fetched1 = await get_repo_config(mock_github_client, "owner/repo")
+    config1 = await get_repo_config(mock_github_client, "owner/repo")
 
     # update mock to return different data
     mock_github_client.get_repo_config.return_value = (
@@ -148,15 +146,11 @@ async def test_get_repo_config_refreshes(mock_github_client):
     )
 
     # second call with refresh
-    config2, fetched2 = await get_repo_config(
-        mock_github_client, "owner/repo", refresh=True
-    )
+    config2 = await get_repo_config(mock_github_client, "owner/repo", refresh=True)
 
     assert config1.dest_org == "owner"
     assert config2.dest_org == "new-org"
     assert config2.dest_name == "new-repo"
-    assert fetched1 is True  # first call should fetch
-    assert fetched2 is True  # refresh should also fetch (not use cache)
     # should be called twice due to refresh
     assert mock_github_client.get_repo_config.call_count == 2
 


### PR DESCRIPTION
Originally discovered by @chapman39 in https://github.com/llnl/smith/runs/92335704760.

When a repository configuration aged out of Hubcast's internal cache, the fetched flag used to gate webhook updates returned True, causing a Hubcast error to be reported to users even when the commit to the default branch did not modify the Hubcast configuration.

This PR switches the gating to `config_changed`, which is derived from the files actually touched by the push event and is a better fit here. Since the fetched return value is no longer used anywhere, it has also been removed from `get_repo_config()`.