### PR TITLE
Convert AccountMap calls to asyncio methods

### DIFF
--- a/src/hubcast/account_map/abc.py
+++ b/src/hubcast/account_map/abc.py
@@ -8,7 +8,7 @@ class AccountMap(ABC):
     """
 
     @abstractmethod
-    def __call__(self, source_user: str) -> str | None:
+    async def __call__(self, source_user: str) -> str | None:
         """
         Return the corresponding destination forge user for a given source forge user
         if one exists.

--- a/src/hubcast/account_map/file.py
+++ b/src/hubcast/account_map/file.py
@@ -45,7 +45,7 @@ class FileMap(AccountMap):
         except (KeyError, TypeError) as e:
             raise FileMapError(f"File map missing Users section. path={path}") from e
 
-    def __call__(self, source_user: str) -> str | None:
+    async def __call__(self, source_user: str) -> str | None:
         """
         Return the destination forge user for a source forge user if one exists.
         """

--- a/src/hubcast/account_map/ldap.py
+++ b/src/hubcast/account_map/ldap.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -13,6 +14,9 @@ log = logging.getLogger(__name__)
 
 # 5 seconds (default is ~30, which is too long)
 ldap.set_option(ldap.OPT_NETWORK_TIMEOUT, 5)
+# bound bind/search operations too; OPT_NETWORK_TIMEOUT only covers connect,
+# without this a hung directory server blocks forever (default is infinite)
+ldap.set_option(ldap.OPT_TIMEOUT, 5)
 
 
 @contextmanager
@@ -73,14 +77,20 @@ class LDAPMap(AccountMap):
         self.bind_dn = bind_dn
         self.bind_password = bind_password
 
-    def __call__(self, source_user: str) -> str | None:
-        # TODO make this a standalone method to make it generic???
+    async def __call__(self, source_user: str) -> str | None:
+        """
+        Async wrapper around the blocking python-ldap lookup; runs it in a
+        thread to keep the event loop free.
+        """
+        return await asyncio.to_thread(self._lookup, source_user)
+
+    def _lookup(self, source_user: str) -> str | None:
         """
         searches the LDAP endpoint for source_user within the search_base and returns
         the value of output_attr.
         Simple bind auth is used if bind_dn is set; otherwise uses SASL/GSSAPI (kerberos).
 
-        Returns None if not found or on error.
+        Returns None if not found; raises HubcastError on LDAP errors.
         """
 
         filterstr = f"({self.input_attr}={source_user})"

--- a/src/hubcast/web/github/handler.py
+++ b/src/hubcast/web/github/handler.py
@@ -65,7 +65,7 @@ class GitHubHandler:
             elif (issue := event.data.get("issue")) and "pull_request" in issue:
                 update_log_context(pull_request_id=issue["number"])
 
-            gitlab_user = self.account_map(github_user)
+            gitlab_user = await self.account_map(github_user)
 
             if gitlab_user is None:
                 log.info("Unauthorized GitHub user")

--- a/tests/test_account_map.py
+++ b/tests/test_account_map.py
@@ -24,15 +24,25 @@ def ldap_map():
     )
 
 
+@pytest.fixture
+def mock_conn():
+    """Mock LDAP connection returned by a patched ldap.initialize."""
+    with patch("ldap.initialize") as mock_init:
+        conn = Mock()
+        mock_init.return_value = conn
+        yield conn
+
+
 ### TESTS
 
 
 # file mapper tests
-def test_file_map():
+@pytest.mark.asyncio
+async def test_file_map():
     account_map = FileMap("tests/data/file_map.yml")
-    assert account_map("alice") == "alice_123"
-    assert account_map("bob") == "bob_456"
-    assert account_map("charlie") is None
+    assert await account_map("alice") == "alice_123"
+    assert await account_map("bob") == "bob_456"
+    assert await account_map("charlie") is None
 
 
 def test_file_map_no_file():
@@ -62,30 +72,24 @@ def test_file_map_missing_users_key():
 # ldap mapper tests
 
 
-def test_ldap_map_match(ldap_map):
+@pytest.mark.asyncio
+async def test_ldap_map_match(ldap_map, mock_conn):
     """If LDAP returns a matching entry, should return the mapped value."""
 
-    with patch("ldap.initialize") as mock_init:
-        mock_conn = Mock()
-        mock_init.return_value = mock_conn
-        mock_conn.search_s.return_value = [("dn", {"uid": [b"caetano_gitlab"]})]
-        mock_conn.unbind_s.return_value = None
+    mock_conn.search_s.return_value = [("dn", {"uid": [b"caetano_gitlab"]})]
 
-        result = ldap_map("caetano_github")
-        assert result == "caetano_gitlab"
+    result = await ldap_map("caetano_github")
+    assert result == "caetano_gitlab"
 
 
-def test_ldap_map_no_match(ldap_map):
+@pytest.mark.asyncio
+async def test_ldap_map_no_match(ldap_map, mock_conn):
     """If LDAP returns no matching entry, should return None."""
 
-    with patch("ldap.initialize") as mock_init:
-        mock_conn = Mock()
-        mock_init.return_value = mock_conn
-        mock_conn.search_s.return_value = []
-        mock_conn.unbind_s.return_value = None
+    mock_conn.search_s.return_value = []
 
-        result = ldap_map("caetano_github")
-        assert result is None
+    result = await ldap_map("caetano_github")
+    assert result is None
 
 
 @pytest.mark.parametrize(
@@ -95,40 +99,32 @@ def test_ldap_map_no_match(ldap_map):
         {"uid": []},  # uid attribute empty
     ],
 )
-def test_ldap_map_attrib_missing(ldap_map, attrs):
+@pytest.mark.asyncio
+async def test_ldap_map_attrib_missing(ldap_map, mock_conn, attrs):
     """Should return None when attribute is missing or empty."""
 
-    with patch("ldap.initialize") as mock_init:
-        mock_conn = Mock()
-        mock_init.return_value = mock_conn
-        mock_conn.search_s.return_value = [("dn", attrs)]
+    mock_conn.search_s.return_value = [("dn", attrs)]
 
-        result = ldap_map("alice")
-
-        assert result is None
+    result = await ldap_map("alice")
+    assert result is None
 
 
-def test_ldap_map_exception(ldap_map):
+@pytest.mark.asyncio
+async def test_ldap_map_exception(ldap_map, mock_conn):
     """If LDAP raises an exception, should raise HubcastError."""
 
-    with patch("ldap.initialize") as mock_init:
-        mock_conn = Mock()
-        mock_init.return_value = mock_conn
-        mock_conn.search_s.side_effect = ldap.LDAPError("something bad")
-        mock_conn.unbind_s.return_value = None
+    mock_conn.search_s.side_effect = ldap.LDAPError("something bad")
 
-        with pytest.raises(HubcastError, match="LDAP query failed"):
-            ldap_map("caetano_github")
+    with pytest.raises(HubcastError, match="LDAP query failed"):
+        await ldap_map("caetano_github")
 
 
-def test_ldap_map_unbind_failure(ldap_map):
+@pytest.mark.asyncio
+async def test_ldap_map_unbind_failure(ldap_map, mock_conn):
     """Should handle unbind failure gracefully."""
 
-    with patch("ldap.initialize") as mock_init:
-        mock_conn = Mock()
-        mock_init.return_value = mock_conn
-        mock_conn.search_s.return_value = [("dn", {"uid": [b"caetano_gitlab"]})]
-        mock_conn.unbind_s.side_effect = ldap.LDAPError("unbind failed")
+    mock_conn.search_s.return_value = [("dn", {"uid": [b"caetano_gitlab"]})]
+    mock_conn.unbind_s.side_effect = ldap.LDAPError("unbind failed")
 
-        result = ldap_map("caetano_github")
-        assert result == "caetano_gitlab"
+    result = await ldap_map("caetano_github")
+    assert result == "caetano_gitlab"

--- a/tests/test_github_handler.py
+++ b/tests/test_github_handler.py
@@ -17,7 +17,7 @@ def handler():
     """Handler with mocked dependencies."""
 
     webhook_secret = "secret"
-    account_map = Mock(return_value="gitlab_user")
+    account_map = AsyncMock(return_value="gitlab_user")
     gh_factory = Mock()
     gh_factory.create_client = Mock(return_value=AsyncMock())
     gl_factory = Mock()


### PR DESCRIPTION
Digging through some of our logs I noticed that occasionally Hubcast was failing a health check due to a slow response. Looking through the code the only thing that stood out to me was that our calls to the LDAP AccountMap are synchronous and so it's possible that a slow response from the LDAP server could block Hubcast for a couple seconds.

This PR converts our AccountMap calls to be asynchronous methods and wraps the LDAP call in a `asyncio.to_thread()` call to push it off the main loop.