### PR TITLE
approve command will mirror even with sync_drafts disabled

### DIFF
--- a/docs/guide-user.md
+++ b/docs/guide-user.md
@@ -34,6 +34,7 @@ Repo:
   delete_closed: true
 
   # Optional: sync draft PRs/MRs (default: true)
+  # regardless of this setting, a draft PR can still be synced manually with `approve`
   sync_drafts: true
 
   # Optional: post message when draft sync is disabled (default: true)
@@ -116,6 +117,8 @@ Replace `@{bot}` with your instance's bot user (e.g., `@lc-hubcast`) or use `/hu
 
 ### Approval
 To securely mirror changes from external collaborators, approvals must be done via commenting on a PR review, ensuring that it is linked to a specific commit.
+
+`approve` always syncs the reviewed commit, even for a draft PR where `sync_drafts` is disabled for the repo.
 
 ![A GitHub pull request review; the user has written a comment `@lc-hubcast approve` to sync the user's contributions.](/docs/img/approve-comment.png)
 

--- a/src/hubcast/web/github/routes.py
+++ b/src/hubcast/web/github/routes.py
@@ -451,6 +451,7 @@ async def sync_pr(
     src_repo_private: bool,
     want_sha: str,
     default_branch: str,
+    force_sync_draft: bool = False,  # allows draft PRs to be manually synced
 ) -> None:
     """Sync the git fork/branch referenced in a PR to GitLab.
 
@@ -490,7 +491,7 @@ async def sync_pr(
     # validate the changes when the default branch config doesn't have issues
     await validate_config_change(gh, changed_files, want_sha)
 
-    if not repo_config.sync_drafts and pull_request["draft"]:
+    if not force_sync_draft and not repo_config.sync_drafts and pull_request["draft"]:
         if repo_config.sync_drafts_msg:
             await gh.set_check_status(
                 want_sha,
@@ -669,7 +670,7 @@ async def respond_comment(
             commit_sha = event.data["review"]["commit_id"]
             pull_request = event.data["pull_request"]
             src_repo_private = pull_request["head"]["repo"]["private"]
-            # sync the approved commit explicitly
+            # sync the approved commit explicitly even if sync_drafts is disabled
             await sync_pr(
                 pull_request,
                 gh,
@@ -678,6 +679,7 @@ async def respond_comment(
                 src_repo_private,
                 want_sha=commit_sha,
                 default_branch=event.data["repository"]["default_branch"],
+                force_sync_draft=True,
             )
             plus_one = True
             log.info(


### PR DESCRIPTION
alternative to: https://github.com/llnl/hubcast/pull/417
closes https://github.com/llnl/hubcast/issues/336

instead of ignoring a user when they ask for draft PRs to be mirrored to GL, allow this to be an override mechanism to mirror commits over when explicitly requested